### PR TITLE
Add persona tiering and compression target learnings

### DIFF
--- a/.claude/commands/learnings/curate/curation-insights.md
+++ b/.claude/commands/learnings/curate/curation-insights.md
@@ -26,6 +26,18 @@ Operational calibration and phase-specific patterns from prior consolidation run
 - **Granular files > monolithic files for selective loading.** Smaller, focused files let the agent load only what's relevant. Split large files when distinct sections serve different tasks — the agent can then pay tokens only for the section it needs
 - **Deduplication has compounding returns.** Content duplicated across N files costs N× tokens when multiple files are loaded in the same conversation. Consolidating to a single authoritative location saves tokens proportional to the overlap
 
+## Compression Target Patterns
+
+The conciseness check (curate step 4) should specifically flag these patterns as compression candidates:
+
+- **Provenance notes** — "Discovered from: building the /api/amm/info route..." adds no teaching value; the pattern stands on its own
+- **Compound-time self-assessments** — "Utility: High — novel pattern" was useful during triage but is noise once the learning is accepted
+- **Debugging trails** — "What didn't work: tried X, then Y" belongs in commit history, not permanent reference docs
+- **Verbose source code** — Multi-line code blocks when an English summary captures the same insight (e.g., a 15-line C++ snippet reducible to "Source: rippled `NetworkOPs.cpp` ~4177-4191")
+- **Redundant structural dividers** — `---` between sections when `##` headings already provide visual separation
+
+**Calibration:** These patterns typically yield ~30% compression without losing teaching value. The goal is fewer tokens per insight, not fewer insights.
+
 ## Phase 2 Patterns
 
 - **Deep dive for large-file MEDIUMs:** When a MEDIUM targets a file with 5+ sections, delegate per-section cross-reference analysis to a Task subagent rather than doing it inline. The subagent produces a per-section table (section title, related skill, coverage status, recommendation).

--- a/.claude/learnings/skill-design.md
+++ b/.claude/learnings/skill-design.md
@@ -126,3 +126,14 @@ Key design choices:
 
 Skill output templates (tables, summaries) should use language meaningful to someone unfamiliar with the skill's internal classification model. Column headers like "Why LOW" reference an internal confidence tier — readers unfamiliar with the HIGH/MEDIUM/LOW system interpret it as "low value" or "low priority." Use action-oriented labels instead (e.g., "Tradeoff" — explains what you'd give up by acting on the item).
 
+## Persona Tiering: Core vs Deep-Reference
+
+When a persona file accumulates enough domain-specific gotchas that signal density starts degrading, split into two tiers:
+
+- **Core (always-loaded):** High-frequency patterns checked on every review — flag usage, casing conventions, trust line prerequisites, arithmetic rules. These belong in the persona file itself.
+- **Deep-reference (conditional):** Operation-specific knowledge relevant only during certain tasks (e.g., AMM pool creation, order book display, fill detection). Reference via `@` pointer to a learnings file; the agent loads it when the task context matches.
+
+**Cut line:** "Check every time I see XRPL code" → core. "Reference when building feature X" → deep-reference.
+
+**When to tier:** The trigger is signal density, not raw line count. If a reviewer would skim past most entries because they're irrelevant to the current task, the file has crossed the threshold. Every entry in core should be worth checking on every review.
+


### PR DESCRIPTION
Capture two patterns from consolidation session:
- Persona tiering (core vs deep-reference) based on signal density
- Compression target patterns for curate conciseness checks

https://claude.ai/code/session_01DgKTcMRusadS6UTJJSVmnn