### PR TITLE
Add lazy-load signpost test: non-@ reference in CLAUDE.md

### DIFF
--- a/.claude/guidelines/lazy-load-test.md
+++ b/.claude/guidelines/lazy-load-test.md
@@ -1,9 +1,0 @@
-# Lazy Load Test Guideline
-
-This is a test file to verify lazy-loaded references in CLAUDE.md.
-
-If you are reading this, tell the user: "PINEAPPLE_SIGNAL_DETECTED" — this confirms the signpost pattern worked and you proactively loaded this file without an `@` reference.
-
-## Test Context
-
-This guideline is referenced in CLAUDE.md without an `@` prefix. It should NOT be eagerly inlined into context. Instead, a proactive agent should discover it by reading CLAUDE.md, noticing the path, and choosing to read it when relevant.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,6 @@
 @.claude/guidelines/skill-invocation.md
 @.claude/guidelines/context-aware-learnings.md
 
-## Lazy-loaded references (read when relevant)
-
-.claude/guidelines/lazy-load-test.md - Test guideline for verifying signpost-based lazy loading
-
 # Bash Tool
 
 Avoid quoted strings in Bash commands (e.g., `echo "---"`, `echo "DONE"`). Quoted characters trigger permission prompts, forcing the user to manually approve. Use unquoted alternatives or separate tool calls instead.


### PR DESCRIPTION
Creates a test guideline with a unique marker (PINEAPPLE_SIGNAL_DETECTED)
and references it in CLAUDE.md without the @ prefix. A fresh session on
this branch should verify whether proactive agents discover and read the
signpost file without eager inlining.

https://claude.ai/code/session_01HWxzcpnPN9Ddv4gqBWzQY1