### PR TITLE
Add final compound step to session-retro skill

### DIFF
--- a/.claude/commands/session-retro/SKILL.md
+++ b/.claude/commands/session-retro/SKILL.md
@@ -24,6 +24,8 @@ End-of-session routine that captures learnings and facilitates a retrospective.
 
 4. **Improvements**: Share your ideas for improvements based on the above. As part of this, consider: did anything this session reveal a guideline that's missing, redundant, or out of sync with how we actually work? Then ask the user if they have additional ideas. Discuss and capture anything actionable.
 
+5. **Final compound**: Once all discussion is complete, invoke `/learnings:compound` again using the Skill tool. The retro discussion itself often produces new insights worth capturing — patterns noticed, guidelines proposed, communication preferences clarified. This second pass ensures those don't get lost.
+
 Run each step sequentially. Lead with your own perspective at each stage, then invite the user's — this is a two-way retro, not an interview. **Do not advance to the next step until the user signals they're done with the current one.** Ask explicitly before moving on.
 
 **This is a conversation, not a facilitated meeting.** The numbered steps are topics, not a script. Don't rush through them. Don't end every message with a formulaic handoff question ("What's your take?", "Ready to move on?"). Respond to what the user actually said — follow up, push back, go deeper. Match the user's pace and energy. If a topic has legs, stay on it. The steps exist so nothing gets skipped, not so you can optimize for completion.


### PR DESCRIPTION
## Summary
- Adds step 5 ("Final compound") to `/session-retro` that invokes `/learnings:compound` a second time after all retro discussion is complete
- The retro discussion itself often surfaces new insights (patterns noticed, guidelines proposed, communication preferences clarified) — this second pass ensures they don't get lost

## Changes
- `.claude/commands/session-retro/SKILL.md` — added step 5 between the improvements discussion and the execution instructions

## Test plan
- [x] Run `/session-retro` and verify the final compound step fires after discussion wraps

🤖 Generated with [Claude Code](https://claude.com/claude-code)