### PR TITLE
feat: Migrate learnings refs to provider slug scheme

### DIFF
--- a/claude/commands/git/team-review-request/SKILL.md
+++ b/claude/commands/git/team-review-request/SKILL.md
@@ -88,7 +88,8 @@ For prompt-free execution, ensure these allow patterns in `~/.claude/settings.lo
 6. **Front-load persona content** — for each selected persona:
    - Read the full persona file
    - If it has `## Extends:`, read parent persona(s) in declaration order
-   - If it (or its parents) has `## Proactive Cross-Refs`, read each listed file
+   - If it (or its parents) has `## Proactive Cross-Refs` or `## Proactive loads`, resolve `provider:` paths before loading: read `~/.claude/learnings-providers.json`, expand `provider:default/path` via the `defaultWriteTarget` provider's `localPath`, and `provider:<name>/path` via the named provider's `localPath`. Skip references whose provider isn't in the config.
+   - Read each resolved proactive file
    - Store the combined content as `PERSONA_CONTENT[persona_name]`
 
 7. **Load domain-relevant learnings** — match `CHANGED_FILES` paths and derived domain terms against learnings filenames:

--- a/claude/commands/set-persona/SKILL.md
+++ b/claude/commands/set-persona/SKILL.md
@@ -44,19 +44,19 @@ Activate a domain-specific lens that shapes how you approach code in this sessio
    - Apply the priorities and focus areas from that point forward in the session
 
 5. **Load proactive knowledge**:
-   - Scan adopted persona (and parent if extended) for `## Proactive loads` sections
-   - Each listed path uses the logical form `learnings/...` (no `~/.claude/` prefix)
-   - Resolve each path by searching these directories in order, loading the first match:
-     1. `~/.claude/learnings-team/learnings/` — shared team learnings (highest precedence)
-     2. `docs/learnings/` — repo-local learnings
-     3. `~/.claude/learnings/` — personal learnings
-     4. `~/.claude/learnings-private/` — private learnings
-   - If a file doesn't exist in any location, warn but don't fail
+   - Scan adopted persona (and parent if extended) for `## Proactive loads` or `## Proactive Cross-Refs` sections
+   - Paths use the `provider:<name>/path` scheme (e.g., `provider:default/java/spring-boot-gotchas.md`)
+   - Resolve each path using provider resolution:
+     1. Read `~/.claude/learnings-providers.json`
+     2. `provider:default/path` → find the provider with `"defaultWriteTarget": true` → `localPath/path`
+     3. `provider:<name>/path` → find the provider by `"name"` → `localPath/path`
+     4. If the named provider doesn't exist in the config, warn but don't fail
+     5. If the resolved file doesn't exist on disk, warn but don't fail
    - Announce: "📚 Loaded proactive gotchas: `xrpl-gotchas.md`, `react-frontend-gotchas.md`"
    - Keep this content active throughout the session
 
 6. **Resolve cross-refs on demand**:
-   - When loading a `## Cross-Refs` entry during the session, apply the same multi-source resolution as proactive loads
+   - When loading a `## Cross-Refs` entry during the session, apply the same provider resolution as proactive loads
 
 ## Prerequisites
 
@@ -65,8 +65,8 @@ For prompt-free execution, add these allow patterns to `~/.claude/settings.local
 ```json
 "Read(~/.claude/commands/set-persona/**)",
 "Read(.claude/personas/**)",
-"Read(~/.claude/learnings/**)",
-"Read(~/.claude/learnings-team/learnings/**)"
+"Read(~/.claude/learnings*/**)",
+"Read(~/.claude/learnings-providers.json)"
 ```
 
 ## Important Notes

--- a/claude/commands/set-persona/architecture-reviewer.md
+++ b/claude/commands/set-persona/architecture-reviewer.md
@@ -46,6 +46,6 @@ Every finding MUST include inline code references — quote the exact problemati
 
 ## Learnings Cross-Refs
 
-- `~/.claude/learnings-team/learnings/code-quality-instincts.md` — naming, logging, dead code, wrapper methods
-- `~/.claude/learnings-team/learnings/process-conventions.md` — MR scoping, review process, infrastructure evidence
-- `~/.claude/learnings-team/learnings/java/spring-boot.md` — multi-module patterns, JPA/Hibernate, Lombok, @Transactional
+- `provider:default/code-quality-instincts.md` — naming, logging, dead code, wrapper methods
+- `provider:default/process-conventions.md` — MR scoping, review process, infrastructure evidence
+- `provider:default/java/spring-boot.md` — multi-module patterns, JPA/Hibernate, Lombok, @Transactional

--- a/claude/commands/set-persona/claude-config-expert.md
+++ b/claude/commands/set-persona/claude-config-expert.md
@@ -10,7 +10,7 @@ Knowledge base for the Claude configuration surface: skills, guidelines, learnin
 - **Memory minimalism**: prefer guidelines (for rules), learnings (for knowledge), or skill references (for shared patterns) over memory. Memory is for facts that don't fit anywhere else — if the content would be useful to a skill or persona, it belongs in a discoverable file, not always-on context
 
 ## Content type placement
-> Full criteria: `~/.claude/learnings-team/learnings/claude-authoring/content-types.md`
+> Full criteria: `provider:default/claude-authoring/content-types.md`
 - Behavioral rule ("always do X") → guideline, not learning or memory
 - Domain knowledge (gotcha, recipe, pattern) → learning
 - Shared patterns consumed by 2+ skills → skill reference (`skill-references/`), not inlined in each skill
@@ -34,20 +34,20 @@ Knowledge base for the Claude configuration surface: skills, guidelines, learnin
 - Gotchas files must stay separate from parent domain files (never merge `*-gotchas.md` into parent)
 
 ## Proactive loads
-- `~/.claude/learnings-team/learnings/claude-authoring/content-types.md`
+- `provider:default/claude-authoring/content-types.md`
 
 ## Cross-Refs
 Load when working in the specific area:
-- `~/.claude/learnings-team/learnings/claude-authoring/skills.md` — skill composition, creation heuristics, responsibility boundaries
-- `~/.claude/learnings-team/learnings/claude-authoring/guidelines.md` — merging overlaps, enforcement gates, scoping
-- `~/.claude/learnings-team/learnings/claude-authoring/claude-md.md` — conditional references, relationships, subdirectory criteria
-- `~/.claude/learnings-team/learnings/claude-authoring/personas.md` — judgment vs recipes, proactive loads, composition
-- `~/.claude/learnings-team/learnings/claude-authoring/learnings.md` — genericization, headers, scope, boundary tests, cross-refs, directories, indexes, splitting
-- `~/.claude/learnings-team/learnings/claude-code/platform.md` — permission patterns, path resolution, platform behavior gotchas
-- `~/.claude/learnings-team/learnings/claude-code/skill-platform-portability.md` — frontmatter features, cross-platform compat, plugin packaging
-- `~/.claude/learnings-team/learnings/code-quality-instincts.md` — universal code quality patterns referenced by personas
-- `~/.claude/learnings-team/learnings/process-conventions.md` — PR scoping, review process, MR conventions
+- `provider:default/claude-authoring/skills.md` — skill composition, creation heuristics, responsibility boundaries
+- `provider:default/claude-authoring/guidelines.md` — merging overlaps, enforcement gates, scoping
+- `provider:default/claude-authoring/claude-md.md` — conditional references, relationships, subdirectory criteria
+- `provider:default/claude-authoring/personas.md` — judgment vs recipes, proactive loads, composition
+- `provider:default/claude-authoring/learnings.md` — genericization, headers, scope, boundary tests, cross-refs, directories, indexes, splitting
+- `provider:default/claude-code/platform.md` — permission patterns, path resolution, platform behavior gotchas
+- `provider:default/claude-code/skill-platform-portability.md` — frontmatter features, cross-platform compat, plugin packaging
+- `provider:default/code-quality-instincts.md` — universal code quality patterns referenced by personas
+- `provider:default/process-conventions.md` — PR scoping, review process, MR conventions
 - `~/.claude/commands/learnings/curate/curation-insights.md` — curation calibration, compression targets
-- `~/.claude/learnings-team/learnings/claude-code/hooks.md` — hook authoring, PreToolUse/PostToolUse mechanics, selective allowlists
-- `~/.claude/learnings-team/learnings/claude-code/multi-agent/patterns.md` — work distribution, synthesis, parallelization, staging, file coordination, verification, trust arc
-- `~/.claude/learnings-team/learnings/claude-code/multi-agent/parallel-plans.md` — parallel plan execution, DAG shape, speedup bounds
+- `provider:default/claude-code/hooks.md` — hook authoring, PreToolUse/PostToolUse mechanics, selective allowlists
+- `provider:default/claude-code/multi-agent/patterns.md` — work distribution, synthesis, parallelization, staging, file coordination, verification, trust arc
+- `provider:default/claude-code/multi-agent/parallel-plans.md` — parallel plan execution, DAG shape, speedup bounds

--- a/claude/commands/set-persona/claude-config-reviewer.md
+++ b/claude/commands/set-persona/claude-config-reviewer.md
@@ -7,7 +7,7 @@ Review lens for PRs that modify the Claude configuration surface: skills, guidel
 ## When reviewing changes
 
 ### Skills
-> Full criteria: `~/.claude/learnings-team/learnings/claude-authoring/skills.md`
+> Full criteria: `provider:default/claude-authoring/skills.md`
 - Does the description include trigger phrases for discoverability?
 - Are permission prerequisites documented?
 - Do `@` references earn their always-on cost? Would a conditional reference suffice?
@@ -19,7 +19,7 @@ Review lens for PRs that modify the Claude configuration surface: skills, guidel
 - Verify producer-consumer contracts if the skill feeds into or consumes from another
 
 ### Skill references (`skill-references/`)
-> Full criteria: `~/.claude/learnings-team/learnings/claude-authoring/skills.md`
+> Full criteria: `provider:default/claude-authoring/skills.md`
 - Is the content consumed by 2+ skills? If only one consumer, inline it in the skill instead
 - Body-only for templates — no posting commands (those belong in platform command references)
 - Are consuming skills reading selectively (after platform detection) rather than `@`-loading both platforms?
@@ -27,20 +27,20 @@ Review lens for PRs that modify the Claude configuration surface: skills, guidel
 - Bug fixes in reference files cascade to all consumers — verify no skill has a stale inline copy
 
 ### Templates (skill-scoped)
-> Full criteria: `~/.claude/learnings-team/learnings/claude-authoring/skills.md`
+> Full criteria: `provider:default/claude-authoring/skills.md`
 - Body-only content — no command mechanics (those belong in platform command refs or skill steps)
 - Does the template live inside the skill directory that uses it?
 - If multiple skills need the same template, promote to `skill-references/`
 
 ### Guidelines
-> Full criteria: `~/.claude/learnings-team/learnings/claude-authoring/guidelines.md`
+> Full criteria: `provider:default/claude-authoring/guidelines.md`
 - Is it universal enough to justify always-on `@` loading from CLAUDE.md?
 - Does it overlap with an existing guideline? Merge > add
 - Is it actually a guideline (shapes behavior universally) or a learning dressed as one?
 - Stack/language/project-specific content belongs in learnings, not guidelines
 
 ### Learnings
-> Full criteria: `~/.claude/learnings-team/learnings/claude-authoring/learnings.md`
+> Full criteria: `provider:default/claude-authoring/learnings.md`
 - Source-vs-echo test: did this learning predate the skill/persona that covers it, or is it a redundant reflection?
 - Reusability test: "Is there another time we'd need this?" — if only one consumer, it may be an echo
 - Persona-learning boundary: does the persona one-liner fully prevent the mistake, or does the learning add recipes/context the rule alone can't trigger?
@@ -49,7 +49,7 @@ Review lens for PRs that modify the Claude configuration surface: skills, guidel
 - Does a file with this domain already exist? Check before creating new files
 
 ### Personas
-> Full criteria: `~/.claude/learnings-team/learnings/claude-authoring/personas.md`
+> Full criteria: `provider:default/claude-authoring/personas.md`
 - Judgment, not recipes — if >50% is step-by-step patterns, it belongs in learnings
 - Proactive Cross-Refs section for gotcha files? Every persona's domain gets one
 - Does it reference shared learnings for cross-cutting instincts (code-quality-instincts.md)?
@@ -57,7 +57,7 @@ Review lens for PRs that modify the Claude configuration surface: skills, guidel
 - Inline short gotchas (~6 steps or fewer), cross-reference longer ones
 
 ### CLAUDE.md files
-> Full criteria: `~/.claude/learnings-team/learnings/claude-authoring/claude-md.md`
+> Full criteria: `provider:default/claude-authoring/claude-md.md`
 - `@` references: is this content needed every session, or should it be a signpost (non-`@`)?
 - State conclusions, not just premises — if two facts must combine for correct behavior, state the result
 - Document relationships, not just inventory
@@ -69,7 +69,7 @@ Review lens for PRs that modify the Claude configuration surface: skills, guidel
 - Inline content over ~15 lines that only one skill consumes on-demand: candidate for extraction to `skill-references/`
 
 ### Memory (last resort)
-> Full criteria: `~/.claude/learnings-team/learnings/claude-authoring/content-types.md`
+> Full criteria: `provider:default/claude-authoring/content-types.md`
 - Challenge every memory addition: could this live in a guideline, learning, skill reference, or persona instead?
 - Memory is always-on context cost — learnings/guidelines are conditional and discoverable
 - Is this actually a fact/context, or a behavioral rule? Rules → guidelines

--- a/claude/commands/set-persona/correctness-reviewer.md
+++ b/claude/commands/set-persona/correctness-reviewer.md
@@ -45,6 +45,6 @@ Every finding MUST include inline code references — quote the exact problemati
 
 ## Learnings Cross-Refs
 
-- `~/.claude/learnings-team/learnings/resilience-patterns.md` — retry classification, fail-fast patterns, thundering herd
-- `~/.claude/learnings-team/learnings/java/spring-boot-gotchas.md` — InterruptedException handling, @Retryable gotchas
-- `~/.claude/learnings-team/learnings/java/concurrency-and-resources.md` — thread safety, interrupt flag, resource leaks
+- `provider:default/resilience-patterns.md` — retry classification, fail-fast patterns, thundering herd
+- `provider:default/java/spring-boot-gotchas.md` — InterruptedException handling, @Retryable gotchas
+- `provider:default/java/concurrency-and-resources.md` — thread safety, interrupt flag, resource leaks

--- a/claude/commands/set-persona/financial-reviewer.md
+++ b/claude/commands/set-persona/financial-reviewer.md
@@ -46,6 +46,6 @@ Every finding MUST include inline code references — quote the exact problemati
 
 ## Learnings Cross-Refs
 
-- `~/.claude/learnings-team/learnings/financial/applications.md` — fee calculation invariants, zero-divisor guards, decimal precision
-- `~/.claude/learnings-team/learnings/financial/domain-ledger-architecture.md` — entry lifecycle, balance composition, reconciliation
-- `~/.claude/learnings-team/learnings/code-quality-instincts.md` — single source of truth, no duplication
+- `provider:default/financial/applications.md` — fee calculation invariants, zero-divisor guards, decimal precision
+- `provider:default/financial/domain-ledger-architecture.md` — entry lifecycle, balance composition, reconciliation
+- `provider:default/code-quality-instincts.md` — single source of truth, no duplication

--- a/claude/commands/set-persona/fintech-ledger-engineer.md
+++ b/claude/commands/set-persona/fintech-ledger-engineer.md
@@ -32,22 +32,22 @@ Domain lens for ledger work — technology-agnostic. Stack-specific child person
 
 ## Code style
 
-Enforce `~/.claude/learnings-team/learnings/code-quality-instincts.md` (no duplication, single source of truth, port intent not idioms).
+Enforce `provider:default/code-quality-instincts.md` (no duplication, single source of truth, port intent not idioms).
 
 ## Proactive Cross-Refs
 
-None at this time. A `~/.claude/learnings-team/learnings/fintech-ledger-gotchas.md` file should be created as operational gotchas accumulate.
+None at this time. A `provider:default/fintech-ledger-gotchas.md` file should be created as operational gotchas accumulate.
 
 ## Cross-Refs
 
 This is a hub persona for the ledger domain cluster. Load when working in the specific area:
 
-- `~/.claude/learnings-team/learnings/financial/domain-ledger-architecture.md` — core schema patterns, balance composition, entry lifecycle, reconciliation architecture; load for any schema design or balance calculation work
-- `~/.claude/learnings-team/learnings/financial/applications.md` — calculation safety invariants, zero-divisor guards, idempotency patterns, decimal precision; load for any fee, amount, or financial calculation work
-- `~/.claude/learnings-team/learnings/financial/saga-distributed-transactions.md` — distributed transaction patterns for multi-service ledger flows, compensation logic, saga state machines; load for any cross-service write coordination
-- `~/.claude/learnings-team/learnings/financial/ledger-testing-strategies.md` — ledger-specific testing invariants (double-entry balance assertions, idempotency harnesses, reconciliation test fixtures); load when writing ledger tests
-- `~/.claude/learnings-team/learnings/financial/event-sourcing-cqrs.md` — event sourcing and CQRS patterns for append-only ledger stores, projection design, eventual consistency tradeoffs; load for read-model or projection work
-- `~/.claude/learnings-team/learnings/financial/chart-of-accounts.md` — CoA design, GL integration, account lifecycle, period-end implications; load for account structure or GL integration work
-- `~/.claude/learnings-team/learnings/financial/period-end-closing.md` — close mechanics, balance snapshots, late-arriving transaction handling, cut-off policies; load for reporting, period close, or snapshot work
-- `~/.claude/learnings-team/learnings/financial/ledger-schema-migration.md` — ledger migration architectures, dual-write patterns, zero-downtime migration strategies for append-only tables; load for schema change or backfill work
-- `~/.claude/learnings-team/learnings/resilience-patterns.md` — dedup-before-process, domain exceptions for integration failures, stale cache silent data loss; load for any consumer or retry boundary work
+- `provider:default/financial/domain-ledger-architecture.md` — core schema patterns, balance composition, entry lifecycle, reconciliation architecture; load for any schema design or balance calculation work
+- `provider:default/financial/applications.md` — calculation safety invariants, zero-divisor guards, idempotency patterns, decimal precision; load for any fee, amount, or financial calculation work
+- `provider:default/financial/saga-distributed-transactions.md` — distributed transaction patterns for multi-service ledger flows, compensation logic, saga state machines; load for any cross-service write coordination
+- `provider:default/financial/ledger-testing-strategies.md` — ledger-specific testing invariants (double-entry balance assertions, idempotency harnesses, reconciliation test fixtures); load when writing ledger tests
+- `provider:default/financial/event-sourcing-cqrs.md` — event sourcing and CQRS patterns for append-only ledger stores, projection design, eventual consistency tradeoffs; load for read-model or projection work
+- `provider:default/financial/chart-of-accounts.md` — CoA design, GL integration, account lifecycle, period-end implications; load for account structure or GL integration work
+- `provider:default/financial/period-end-closing.md` — close mechanics, balance snapshots, late-arriving transaction handling, cut-off policies; load for reporting, period close, or snapshot work
+- `provider:default/financial/ledger-schema-migration.md` — ledger migration architectures, dual-write patterns, zero-downtime migration strategies for append-only tables; load for schema change or backfill work
+- `provider:default/resilience-patterns.md` — dedup-before-process, domain exceptions for integration failures, stale cache silent data loss; load for any consumer or retry boundary work

--- a/claude/commands/set-persona/java-backend.md
+++ b/claude/commands/set-persona/java-backend.md
@@ -22,25 +22,25 @@
 
 ## Code style
 
-Enforce `~/.claude/learnings-team/learnings/code-quality-instincts.md` (no duplication, single source of truth, port intent not idioms).
+Enforce `provider:default/code-quality-instincts.md` (no duplication, single source of truth, port intent not idioms).
 
 ## Proactive Cross-Refs
 
-- `~/.claude/learnings-team/learnings/java/spring-boot-gotchas.md`
+- `provider:default/java/spring-boot-gotchas.md`
 
 ## Cross-Refs
 
 Load when working in the specific area:
-- `~/.claude/learnings-team/learnings/java/spring-boot.md` — Multi-module patterns, Flyway gotchas, JPA/Hibernate annotations, Lombok patterns, @Transactional boundaries, config pitfalls
-- `~/.claude/learnings-team/learnings/api-design.md` — Consistent response shapes, DRY validation, security hardening, contract audit approach
-- `~/.claude/learnings-team/learnings/resilience-patterns.md` — Dedup-before-process, domain exceptions for integration failures, stale cache silent data loss
-- `~/.claude/learnings-team/learnings/financial/applications.md` — Fee calculation invariants, zero-divisor guards, command-query separation in financial state
-- `~/.claude/learnings-team/learnings/process-conventions.md` — MR scoping, review process, infrastructure evidence patterns
-- `~/.claude/learnings-team/learnings/code-quality-instincts.md` — Universal code quality patterns: naming, logging, dead code, wrapper methods
-- `~/.claude/learnings-team/learnings/aws/messaging.md` — SQS/SNS/EventBridge patterns: queue selection, idempotent consumers, DLQ config, backpressure, Spring Cloud AWS
-- `~/.claude/learnings-team/learnings/postgresql-query-patterns.md` — Window functions, CTEs, JSONB operations, partial indexes, partitioning strategy
-- `~/.claude/learnings-team/learnings/newman-postman.md` — Newman skipRequest gotchas, conditional assertions for idempotent seeding, export-environment manifest bridge
-- `~/.claude/learnings-team/learnings/local-dev-seeding.md` — Hybrid API + SQL seeding architecture, schema drift detection, deterministic seed UUIDs
-- `~/.claude/learnings-team/learnings/java/infosec-gotchas.md` — JWT validation, CORS, secrets management, dependency vulnerabilities
-- `~/.claude/learnings-team/learnings/java/observability-gotchas.md` — Logging pitfalls, metric cardinality, trace context propagation
-- `~/.claude/learnings-team/learnings/java/observability.md` — Structured logging, distributed tracing, health checks, alerting patterns
+- `provider:default/java/spring-boot.md` — Multi-module patterns, Flyway gotchas, JPA/Hibernate annotations, Lombok patterns, @Transactional boundaries, config pitfalls
+- `provider:default/api-design.md` — Consistent response shapes, DRY validation, security hardening, contract audit approach
+- `provider:default/resilience-patterns.md` — Dedup-before-process, domain exceptions for integration failures, stale cache silent data loss
+- `provider:default/financial/applications.md` — Fee calculation invariants, zero-divisor guards, command-query separation in financial state
+- `provider:default/process-conventions.md` — MR scoping, review process, infrastructure evidence patterns
+- `provider:default/code-quality-instincts.md` — Universal code quality patterns: naming, logging, dead code, wrapper methods
+- `provider:default/aws/messaging.md` — SQS/SNS/EventBridge patterns: queue selection, idempotent consumers, DLQ config, backpressure, Spring Cloud AWS
+- `provider:default/postgresql-query-patterns.md` — Window functions, CTEs, JSONB operations, partial indexes, partitioning strategy
+- `provider:default/newman-postman.md` — Newman skipRequest gotchas, conditional assertions for idempotent seeding, export-environment manifest bridge
+- `provider:default/local-dev-seeding.md` — Hybrid API + SQL seeding architecture, schema drift detection, deterministic seed UUIDs
+- `provider:default/java/infosec-gotchas.md` — JWT validation, CORS, secrets management, dependency vulnerabilities
+- `provider:default/java/observability-gotchas.md` — Logging pitfalls, metric cardinality, trace context propagation
+- `provider:default/java/observability.md` — Structured logging, distributed tracing, health checks, alerting patterns

--- a/claude/commands/set-persona/java-devops.md
+++ b/claude/commands/set-persona/java-devops.md
@@ -22,13 +22,13 @@
 ## Known gotchas & platform specifics
 
 ### Metrics & Observability
-- Follow the 6-step metrics discussion process (gather → map → gap-analyze → propose → prune → cardinality-check) before adding any metric — see `~/.claude/learnings-team/learnings/java/observability-gotchas.md` for the full checklist and Micrometer API traps
+- Follow the 6-step metrics discussion process (gather → map → gap-analyze → propose → prune → cardinality-check) before adding any metric — see `provider:default/java/observability-gotchas.md` for the full checklist and Micrometer API traps
 
 ## Proactive Cross-Refs
 
-- `~/.claude/learnings-team/learnings/java/observability-gotchas.md`
+- `provider:default/java/observability-gotchas.md`
 
 ## Cross-Refs
 
 Load when working in the specific area:
-- `~/.claude/learnings-team/learnings/java/observability.md` — Micrometer patterns, metric naming, cardinality control, structured logging with MDC
+- `provider:default/java/observability.md` — Micrometer patterns, metric naming, cardinality control, structured logging with MDC

--- a/claude/commands/set-persona/java-fintech.md
+++ b/claude/commands/set-persona/java-fintech.md
@@ -18,4 +18,4 @@ Composition persona for Java-based ledger systems. Inherits ledger correctness j
 ## Cross-Refs
 
 Load when working in the specific area:
-- `~/.claude/learnings-team/learnings/postgresql-query-patterns.md` — PostgreSQL-specific ledger table design: DECIMAL precision, partitioning by period, partial indexes on open periods, migration safety
+- `provider:default/postgresql-query-patterns.md` — PostgreSQL-specific ledger table design: DECIMAL precision, partitioning by period, partial indexes on open periods, migration safety

--- a/claude/commands/set-persona/java-infosec.md
+++ b/claude/commands/set-persona/java-infosec.md
@@ -8,7 +8,7 @@
 - Data protection: encryption at rest and in transit, PII handling, audit logging
 
 ## When reviewing or writing code
-- Apply the security tripwires from `~/.claude/learnings-team/learnings/java/infosec-gotchas.md` — every endpoint, every input path, every error response
+- Apply the security tripwires from `provider:default/java/infosec-gotchas.md` — every endpoint, every input path, every error response
 - Think like an attacker: what's the least-privilege path to data exfiltration or privilege escalation?
 
 ## When making tradeoffs
@@ -19,4 +19,4 @@
 
 ## Proactive Cross-Refs
 
-- `~/.claude/learnings-team/learnings/java/infosec-gotchas.md`
+- `provider:default/java/infosec-gotchas.md`

--- a/claude/commands/set-persona/performance-reviewer.md
+++ b/claude/commands/set-persona/performance-reviewer.md
@@ -47,6 +47,6 @@ Every finding MUST include inline code references — quote the exact problemati
 
 ## Learnings Cross-Refs
 
-- `~/.claude/learnings-team/learnings/postgresql-query-patterns.md` — window functions, CTEs, partial indexes, partitioning
-- `~/.claude/learnings-team/learnings/java/observability-gotchas.md` — metric cardinality, timer patterns
-- `~/.claude/learnings-team/learnings/java/observability.md` — Grafana PromQL, structured logging patterns
+- `provider:default/postgresql-query-patterns.md` — window functions, CTEs, partial indexes, partitioning
+- `provider:default/java/observability-gotchas.md` — metric cardinality, timer patterns
+- `provider:default/java/observability.md` — Grafana PromQL, structured logging patterns

--- a/claude/commands/set-persona/platform-engineer.md
+++ b/claude/commands/set-persona/platform-engineer.md
@@ -26,12 +26,12 @@
 
 ## Proactive Cross-Refs
 
-- `~/.claude/learnings-team/learnings/gitlab-ci-cd.md`
+- `provider:default/gitlab-ci-cd.md`
 
 ## Cross-Refs
 
 Load when working in the specific area:
-- `~/.claude/learnings-team/learnings/aws/patterns.md` — EventBridge scheduling limits, ECS Fargate cost-aware defaults
-- `~/.claude/learnings-team/learnings/git-patterns.md` — Parallel branch rebase with worktrees, pnpm lockfile conflicts, worktree settings isolation, zsh glob expansion
-- `~/.claude/learnings-team/learnings/bash-patterns.md` — Shell env default ordering, shared test library pattern, `set -e`/`pipefail` traps, teardown ordering
-- `~/.claude/learnings-team/learnings/gitlab-ci-cd.md` — GitLab CI/CD patterns, debugging with glab API, MR API endpoints, Docker build/push stage rules
+- `provider:default/aws/patterns.md` — EventBridge scheduling limits, ECS Fargate cost-aware defaults
+- `provider:default/git-patterns.md` — Parallel branch rebase with worktrees, pnpm lockfile conflicts, worktree settings isolation, zsh glob expansion
+- `provider:default/bash-patterns.md` — Shell env default ordering, shared test library pattern, `set -e`/`pipefail` traps, teardown ordering
+- `provider:default/gitlab-ci-cd.md` — GitLab CI/CD patterns, debugging with glab API, MR API endpoints, Docker build/push stage rules

--- a/claude/commands/set-persona/react-frontend.md
+++ b/claude/commands/set-persona/react-frontend.md
@@ -7,7 +7,7 @@
 - Accessibility by default: semantic HTML first, ARIA only when native semantics can't express the interaction, keyboard navigation for all interactive elements
 - Testing strategy: assert side effects over transient UI state, scope selectors to containers, role-based over text-based locators
 - Design system discipline: centralize tokens before component-level changes, extract abstractions only when a second consumer appears
-- Code quality: apply `~/.claude/learnings-team/learnings/code-quality-instincts.md` principles throughout (no duplication, single source of truth, port intent not idioms)
+- Code quality: apply `provider:default/code-quality-instincts.md` principles throughout (no duplication, single source of truth, port intent not idioms)
 
 ## When reviewing or writing code
 - Flag any `setState` called synchronously inside `useEffect` — use lazy `useState` initializers for hydration/init, render-time sync (`if (prev !== current)` pattern) for prop changes
@@ -29,21 +29,21 @@
 ## Known gotchas & platform specifics
 
 ### Next.js 16 / Turbopack
-- Platform gotchas (proxy.ts rename, async dynamic params, Turbopack build requirements) — see `~/.claude/learnings-team/learnings/frontend/nextjs.md`
+- Platform gotchas (proxy.ts rename, async dynamic params, Turbopack build requirements) — see `provider:default/frontend/nextjs.md`
 
 ## Proactive Cross-Refs
 
-- `~/.claude/learnings-team/learnings/frontend/react-frontend-gotchas.md`
+- `provider:default/frontend/react-frontend-gotchas.md`
 
 ## Cross-Refs
 
 These learning files contain full recipes, code examples, and edge cases for each sub-domain. Load when working in the specific area:
 
-- `~/.claude/learnings-team/learnings/code-quality-instincts.md` — Universal code quality instincts (no duplication, single source of truth, port intent)
-- `~/.claude/learnings-team/learnings/frontend/react-patterns.md` — React 19 setState rules, hydration gating, lazy initializers, hook extraction, two-tier design, modals, polling
-- `~/.claude/learnings-team/learnings/reactive-data-patterns.md` — Reactive refresh, client-side expiration tracking, silent fetch pattern
-- `~/.claude/learnings-team/learnings/frontend/nextjs.md` — Next.js 16 proxy.ts, dynamic params, Turbopack gotchas, rate limiter wiring
-- `~/.claude/learnings-team/learnings/frontend/accessibility-patterns.md` — ARIA attribute patterns with code examples
-- `~/.claude/learnings-team/learnings/frontend/ui-patterns.md` — Tailwind tooltips, SVG gotchas, design token centralization
-- `~/.claude/learnings-team/learnings/testing-patterns.md` — Vitest/RTL stack, vi.mock hoisting, route handler test patterns, shared test helpers, jsdom gotchas
-- `~/.claude/learnings-team/learnings/playwright-patterns.md` — 17 testing patterns covering selectors, state, modals, assertions
+- `provider:default/code-quality-instincts.md` — Universal code quality instincts (no duplication, single source of truth, port intent)
+- `provider:default/frontend/react-patterns.md` — React 19 setState rules, hydration gating, lazy initializers, hook extraction, two-tier design, modals, polling
+- `provider:default/reactive-data-patterns.md` — Reactive refresh, client-side expiration tracking, silent fetch pattern
+- `provider:default/frontend/nextjs.md` — Next.js 16 proxy.ts, dynamic params, Turbopack gotchas, rate limiter wiring
+- `provider:default/frontend/accessibility-patterns.md` — ARIA attribute patterns with code examples
+- `provider:default/frontend/ui-patterns.md` — Tailwind tooltips, SVG gotchas, design token centralization
+- `provider:default/testing-patterns.md` — Vitest/RTL stack, vi.mock hoisting, route handler test patterns, shared test helpers, jsdom gotchas
+- `provider:default/playwright-patterns.md` — 17 testing patterns covering selectors, state, modals, assertions

--- a/claude/commands/set-persona/reviewer.md
+++ b/claude/commands/set-persona/reviewer.md
@@ -3,7 +3,7 @@
 Base persona for all code review workflows. Provides universal review instincts — code quality, process conventions, and review etiquette. Domain-specific reviewer personas extend this.
 
 ## Domain priorities
-- **Code quality** — enforce patterns from `~/.claude/learnings-team/learnings/code-quality-instincts.md` across all reviews
+- **Code quality** — enforce patterns from `provider:default/code-quality-instincts.md` across all reviews
 - **Process conventions** — PR structure, review etiquette, commit hygiene
 - **Lean over noisy** — don't post empty reviews; emoji reactions for resolved items; summary = themes, inline = specifics
 
@@ -19,6 +19,6 @@ Base persona for all code review workflows. Provides universal review instincts 
 - Silence is a valid review outcome — no findings = no post
 
 ## Proactive loads
-- `~/.claude/learnings-team/learnings/code-quality-instincts.md`
-- `~/.claude/learnings-team/learnings/process-conventions.md`
-- `~/.claude/learnings-team/learnings/code-review-methodology.md`
+- `provider:default/code-quality-instincts.md`
+- `provider:default/process-conventions.md`
+- `provider:default/code-review-methodology.md`

--- a/claude/commands/set-persona/security-reviewer.md
+++ b/claude/commands/set-persona/security-reviewer.md
@@ -43,4 +43,4 @@ Every finding MUST include inline code references — quote the exact problemati
 
 ## Learnings Cross-Refs
 
-- `~/.claude/learnings-team/learnings/java/infosec-gotchas.md` — JWT validation, CORS, secrets management, dependency vulnerabilities
+- `provider:default/java/infosec-gotchas.md` — JWT validation, CORS, secrets management, dependency vulnerabilities

--- a/claude/commands/set-persona/team-lead.md
+++ b/claude/commands/set-persona/team-lead.md
@@ -31,6 +31,6 @@ Apply the finding prioritization axes from `review-conventions.md`. In a multi-a
 - Honest uncertainty > false precision — "this might be an issue" is more useful than a confident wrong call
 
 ## Cross-Refs
-- `~/.claude/learnings/review-conventions.md` — finding prioritization, reversibility weighting, scope discipline
-- `~/.claude/learnings/claude-code/multi-agent/orchestration.md` — work distribution, synthesis, context compaction
-- `~/.claude/learnings/claude-code/multi-agent/coordination.md` — worktree commit/merge, file coordination
+- `provider:personal/review-conventions.md` — finding prioritization, reversibility weighting, scope discipline
+- `provider:personal/claude-code/multi-agent/orchestration.md` — work distribution, synthesis, context compaction
+- `provider:personal/claude-code/multi-agent/coordination.md` — worktree commit/merge, file coordination

--- a/claude/commands/set-persona/typescript-devops.md
+++ b/claude/commands/set-persona/typescript-devops.md
@@ -15,10 +15,10 @@
 
 ## Proactive Cross-Refs
 
-- `~/.claude/learnings-team/learnings/frontend/typescript-ci-gotchas.md`
+- `provider:default/frontend/typescript-ci-gotchas.md`
 
 ## Cross-Refs
 
 Load when working in the specific area:
-- `~/.claude/learnings/vercel-deployment.md` — Cron job limits, Vercel Postgres (Neon HTTP driver), nullable column comparisons (personal only, not in learnings-team)
-- `~/.claude/learnings-team/learnings/gitlab-ci-cd.md` — GitLab CI/CD patterns, debugging, GitHub Actions and GitLab CI tripwires, Docker build stage sharing
+- `provider:personal/vercel-deployment.md` — Cron job limits, Vercel Postgres (Neon HTTP driver), nullable column comparisons (personal provider only)
+- `provider:default/gitlab-ci-cd.md` — GitLab CI/CD patterns, debugging, GitHub Actions and GitLab CI tripwires, Docker build stage sharing

--- a/claude/commands/set-persona/xrpl-typescript-fullstack.md
+++ b/claude/commands/set-persona/xrpl-typescript-fullstack.md
@@ -4,13 +4,13 @@
 - XRPL integration: correct transaction construction, flag usage, funded offer semantics, currency hex encoding, trust line prerequisites
 - API design: consistent response shapes (always include nullable fields), proper HTTP semantics, input validation at system boundaries
 - React/Next.js patterns: SSR hydration safety, error boundary isolation for data-driven sections, React 19 idioms
-- TypeScript rigor: leverage the type system to catch XRPL field casing mismatches and encoding boundary issues; apply `~/.claude/learnings-team/learnings/code-quality-instincts.md` (no duplication, single source of truth, port intent not idioms)
+- TypeScript rigor: leverage the type system to catch XRPL field casing mismatches and encoding boundary issues; apply `provider:default/code-quality-instincts.md` (no duplication, single source of truth, port intent not idioms)
 - Wallet security: secrets stay client-side, prefer wallet adapter integrations over raw seed handling
 - Vercel/serverless awareness: design around stateless function invocations, WebSocket singleton lifetime, cold start implications
 
 ## When reviewing or writing code
 - For order book display, use `taker_gets_funded ?? taker_gets` AND filter where BOTH amount > 0 AND price > 0 — filtering only on amount misses zero-price rows from `taker_pays_funded: "0"`
-- Verify all financial arithmetic uses `BigNumber.js` — never use `parseFloat()` or native operators (`+`, `-`, `*`, `/`) on prices, amounts, totals, or spreads (see `~/.claude/learnings-team/learnings/financial/numeric-precision-strategy.md` for patterns)
+- Verify all financial arithmetic uses `BigNumber.js` — never use `parseFloat()` or native operators (`+`, `-`, `*`, `/`) on prices, amounts, totals, or spreads (see `provider:default/financial/numeric-precision-strategy.md` for patterns)
 - Check that request-level logic (rate limiting, logging) uses `proxy.ts`, not `middleware.ts` — Next.js 16 renamed the convention and having both causes a build error
 - Wrap new data-fetching UI sections in error boundaries — external ledger data can have unexpected shapes
 - Prefer named functions over IIFEs (`(() => { ... })()`) — if logic needs a block, extract a helper
@@ -27,34 +27,34 @@
 ## Known gotchas & platform specifics
 
 ### XRPL
-Offer semantics, flag bit positions, trust lines, AMM, validation, funded fields — see `~/.claude/learnings-team/learnings/xrpl/gotchas.md` (Proactive load). For fills detection, RippleState sign convention, and orderbook internals — see `~/.claude/learnings-team/learnings/xrpl/patterns.md`.
+Offer semantics, flag bit positions, trust lines, AMM, validation, funded fields — see `provider:default/xrpl/gotchas.md` (Proactive load). For fills detection, RippleState sign convention, and orderbook internals — see `provider:default/xrpl/patterns.md`.
 
 ### Next.js 16 / Turbopack
-Platform gotchas (proxy.ts rename, async dynamic params, Turbopack build requirements, rate limiter wiring) — see `~/.claude/learnings-team/learnings/frontend/nextjs.md` and `~/.claude/learnings-team/learnings/frontend/react-frontend-gotchas.md` (Proactive load).
+Platform gotchas (proxy.ts rename, async dynamic params, Turbopack build requirements, rate limiter wiring) — see `provider:default/frontend/nextjs.md` and `provider:default/frontend/react-frontend-gotchas.md` (Proactive load).
 
 ### Vercel / Serverless
-WebSocket singleton lifetime, in-memory rate limiter scope — see `~/.claude/learnings-team/learnings/xrpl/patterns.md` and `~/.claude/learnings-team/learnings/frontend/nextjs.md`.
+WebSocket singleton lifetime, in-memory rate limiter scope — see `provider:default/xrpl/patterns.md` and `provider:default/frontend/nextjs.md`.
 
 ### TypeScript / Browser Boundaries
-Buffer/TextEncoder, shared encoding fixtures, URI XSS — see `~/.claude/learnings-team/learnings/xrpl/gotchas.md`.
+Buffer/TextEncoder, shared encoding fixtures, URI XSS — see `provider:default/xrpl/gotchas.md`.
 
 ## Proactive Cross-Refs
 
-- `~/.claude/learnings-team/learnings/xrpl/gotchas.md`
-- `~/.claude/learnings-team/learnings/frontend/react-frontend-gotchas.md`
+- `provider:default/xrpl/gotchas.md`
+- `provider:default/frontend/react-frontend-gotchas.md`
 
 ## Cross-Refs
 
 Load when working in the specific area:
-- `~/.claude/learnings-team/learnings/frontend/react-patterns.md` — React 19 setState rules, hydration gating, lazy initializers, hook extraction, two-tier design, modals, polling
-- `~/.claude/learnings-team/learnings/frontend/nextjs.md` — Next.js 16 proxy.ts, dynamic params, Turbopack gotchas, rate limiter wiring
-- `~/.claude/learnings-team/learnings/xrpl/patterns.md` — Orderbook semantics, funded offers, RippleState, fills detection, crossing offers for testing
-- `~/.claude/learnings-team/learnings/xrpl/amm.md` — AMM constant-product formulas, CLOB+AMM interleaved fill estimation
-- `~/.claude/learnings-team/learnings/xrpl/dex-data.md` — OnTheDEX API endpoints, OHLC/ticker response shapes
-- `~/.claude/learnings-team/learnings/xrpl/permissioned-domains.md` — XLS-70/80/81 permissioned domains, credentials, permissioned DEX
-- `~/.claude/learnings-team/learnings/financial/numeric-precision-strategy.md` — BigNumber.js rules for financial arithmetic, comparison traps, precision strategy
-- `~/.claude/learnings-team/learnings/financial/order-book-pricing.md` — Mid-price approaches, slippage estimation, midprice module design
-- `~/.claude/learnings-team/learnings/reactive-data-patterns.md` — Reactive refresh, client-side expiration tracking, silent fetch, balance validation for exchange orders
-- `~/.claude/learnings-team/learnings/xrpl/cross-currency-payments.md` — Payment engine two-pass algorithm, pathfinding source_amount, TransferRate, SendMax semantics, NoRipple rules
-- `~/.claude/learnings-team/learnings/api-design.md` — Consistent response shapes, DRY validation, security hardening, contract audit approach
-- `~/.claude/learnings-team/learnings/financial/domain-ledger-architecture.md` — core ledger schema, balance composition, reconciliation (via fintech-ledger-engineer persona for crypto ledger work)
+- `provider:default/frontend/react-patterns.md` — React 19 setState rules, hydration gating, lazy initializers, hook extraction, two-tier design, modals, polling
+- `provider:default/frontend/nextjs.md` — Next.js 16 proxy.ts, dynamic params, Turbopack gotchas, rate limiter wiring
+- `provider:default/xrpl/patterns.md` — Orderbook semantics, funded offers, RippleState, fills detection, crossing offers for testing
+- `provider:default/xrpl/amm.md` — AMM constant-product formulas, CLOB+AMM interleaved fill estimation
+- `provider:default/xrpl/dex-data.md` — OnTheDEX API endpoints, OHLC/ticker response shapes
+- `provider:default/xrpl/permissioned-domains.md` — XLS-70/80/81 permissioned domains, credentials, permissioned DEX
+- `provider:default/financial/numeric-precision-strategy.md` — BigNumber.js rules for financial arithmetic, comparison traps, precision strategy
+- `provider:default/financial/order-book-pricing.md` — Mid-price approaches, slippage estimation, midprice module design
+- `provider:default/reactive-data-patterns.md` — Reactive refresh, client-side expiration tracking, silent fetch, balance validation for exchange orders
+- `provider:default/xrpl/cross-currency-payments.md` — Payment engine two-pass algorithm, pathfinding source_amount, TransferRate, SendMax semantics, NoRipple rules
+- `provider:default/api-design.md` — Consistent response shapes, DRY validation, security hardening, contract audit approach
+- `provider:default/financial/domain-ledger-architecture.md` — core ledger schema, balance composition, reconciliation (via fintech-ledger-engineer persona for crypto ledger work)

--- a/claude/commands/sweep/work-items/clarifier-prompt.md
+++ b/claude/commands/sweep/work-items/clarifier-prompt.md
@@ -18,15 +18,15 @@ You are an autonomous clarifier agent. Your job is to read a work item that lack
 
 {@../preflight.md}
 
-## Step 6: Self-Comment Check
+## Step 7: Self-Comment Check
 
-Using the `last_comment_body` from Step 4's API response: if the last comment body contains `Role:` followed by `Sweeper` or `Sweeper-Confirm`, this is a sweeper comment — not new human input. If status.md already shows `milestone: done` (a prior pass completed), set `milestone: skipped` in `{ISSUE_DIR}/status.md` and exit. Directives override this check.
+Using the `last_comment_body` from Step 5's API response: if the last comment body contains `Role:` followed by `Sweeper` or `Sweeper-Confirm`, this is a sweeper comment — not new human input. If status.md already shows `milestone: done` (a prior pass completed), set `milestone: skipped` in `{ISSUE_DIR}/status.md` and exit. Directives override this check.
 
-## Step 7: Persona Auto-Detection
+## Step 8: Persona Auto-Detection
 
 Read and follow `~/.claude/skill-references/persona-auto-detect.md`.
 
-## Step 8: Search Learnings for Domain Expertise
+## Step 9: Search Learnings for Domain Expertise
 
 Before investigating code, search for relevant learnings. Domain knowledge helps you ask sharper questions — instead of "what should happen when X?", you can say "the team's pattern for X is Y (per `gotchas.md`) — should this follow the same pattern, or is there a reason to diverge?"
 
@@ -44,14 +44,14 @@ If no matches: `📚 [pre-clarify] no matching learnings found`
 
 **Use loaded learnings to sharpen questions.** Reference specific patterns, gotchas, or conventions from learnings when formulating questions. This transforms generic questions into domain-informed ones that demonstrate codebase understanding and help the issue author make faster decisions.
 
-## Step 9: Investigate the Codebase
+## Step 10: Investigate the Codebase
 
 Explore relevant code to understand:
 - What the current behavior is
 - What files would likely need changing
 - What ambiguities exist (multiple valid interpretations)
 
-## Step 10: Draft and Post Questions
+## Step 11: Draft and Post Questions
 
 Write 2-5 specific, actionable questions. Each question must:
 - Reference specific code or files when relevant
@@ -90,7 +90,7 @@ I looked into this and have a few questions before implementation can proceed:
 - Do NOT post vague or generic questions
 - Do NOT modify any repository files
 
-## Step 11: Write Artifacts
+## Step 12: Write Artifacts
 
 ### result.md
 
@@ -129,7 +129,7 @@ Then add any new observations: codebase insights, architectural patterns discove
 
 ### status.md
 
-**Re-fetch watermark after posting.** Your comment in Step 9 changed the issue's `updatedAt` and added a new comment ID. Fetch the current values now:
+**Re-fetch watermark after posting.** Your comment in Step 11 changed the issue's `updatedAt` and added a new comment ID. Fetch the current values now:
 ```bash
 gh issue view {ISSUE_NUMBER} --json updatedAt,comments --jq '{updatedAt, last_comment_id: (.comments[-1].id // null)}'
 ```

--- a/claude/commands/sweep/work-items/confirmer-prompt.md
+++ b/claude/commands/sweep/work-items/confirmer-prompt.md
@@ -20,15 +20,15 @@ You are an autonomous confirmer agent. A clarifier previously posted questions o
 
 {@../preflight.md}
 
-## Step 6: Self-Comment Check
+## Step 7: Self-Comment Check
 
-Using the `last_comment_body` from Step 4's API response: if the last comment body contains `Role:` followed by `Sweeper-Confirm` or `Sweeper`, this is a sweeper comment — not new human input. If status.md already shows `milestone: done` (a prior pass completed), set `milestone: skipped` in `{ISSUE_DIR}/status.md` and exit. Directives override this check.
+Using the `last_comment_body` from Step 5's API response: if the last comment body contains `Role:` followed by `Sweeper-Confirm` or `Sweeper`, this is a sweeper comment — not new human input. If status.md already shows `milestone: done` (a prior pass completed), set `milestone: skipped` in `{ISSUE_DIR}/status.md` and exit. Directives override this check.
 
-## Step 7: Persona Auto-Detection
+## Step 8: Persona Auto-Detection
 
 Read and follow `~/.claude/skill-references/persona-auto-detect.md`.
 
-## Step 8: Search Learnings for Domain Expertise
+## Step 9: Search Learnings for Domain Expertise
 
 Before investigating code, search for relevant learnings.
 
@@ -43,11 +43,11 @@ d. **Announce results.**
 ```
 If no matches: `📚 [pre-confirm] no matching learnings found`
 
-## Step 9: Analyze Q&A Thread & Investigate Code
+## Step 10: Analyze Q&A Thread & Investigate Code
 
 Read the comment thread. Identify the clarifier's questions, operator's answers, and design decisions. Then explore relevant code to validate — verify files exist, scope assertions are accurate, and your plan accounts for actual code state.
 
-## Step 10: Draft and Post Confirmation
+## Step 11: Draft and Post Confirmation
 
 Post a comment with: (1) your understanding of each answer in your own words (not parroting), flagging tensions or implications; (2) a concrete implementation plan with files, phases, and verification; (3) open questions only if genuine; (4) explicit ask for confirmation.
 
@@ -98,7 +98,7 @@ Does this plan match your intent? Reply with corrections, or "implement" to proc
 - Do NOT implement changes, create branches, or modify repo files
 - Do NOT skip the confirmation step — even if the plan seems obvious
 
-## Step 11: Write Artifacts
+## Step 12: Write Artifacts
 
 ### result.md
 
@@ -128,7 +128,7 @@ Append a dated section to `{ISSUE_DIR}/learnings.md`. Start with **Learnings pro
 
 ### status.md
 
-**Re-fetch watermark after posting.** Your comment in Step 9 changed the issue's `updatedAt` and added a new comment ID. Fetch the current values now:
+**Re-fetch watermark after posting.** Your comment in Step 11 changed the issue's `updatedAt` and added a new comment ID. Fetch the current values now:
 ```bash
 gh issue view {ISSUE_NUMBER} --json updatedAt,comments --jq '{updatedAt, last_comment_id: (.comments[-1].id // null)}'
 ```

--- a/claude/commands/sweep/work-items/implementer-prompt.md
+++ b/claude/commands/sweep/work-items/implementer-prompt.md
@@ -65,7 +65,7 @@ Before writing code, state:
 
 Re-read `{RUN_DIR}/directives.md` and `{ISSUE_DIR}/directives.md` if they exist. The director may have written new directives since Step 3 (e.g., "post confirmation before implementing"). Incorporate any new instructions before proceeding.
 
-## Step 10b: Post Implementation Intent
+## Step 11b: Post Implementation Intent
 
 Before starting implementation, post a status comment on the issue so the conversation thread shows work is underway:
 
@@ -73,7 +73,7 @@ Before starting implementation, post a status comment on the issue so the conver
 gh issue comment {ISSUE_NUMBER} --body "$(cat <<'COMMENT'
 ## Starting implementation
 
-**Plan summary**: <1-3 sentences from Step 9 — what files, what change, how verified>
+**Plan summary**: <1-3 sentences from Step 10 — what files, what change, how verified>
 **Persona**: {PERSONA_NAME}
 
 ---
@@ -83,7 +83,7 @@ COMMENT
 )"
 ```
 
-## Step 11: Implement
+## Step 12: Implement
 
 Make the changes. Follow existing code patterns and conventions. Keep changes minimal and focused on the work item.
 

--- a/claude/commands/sweep/work-items/implementer-prompt.md
+++ b/claude/commands/sweep/work-items/implementer-prompt.md
@@ -26,11 +26,11 @@ If this fails with a permission error, write `milestone: errored` and `error: pe
 
 {@../preflight.md}
 
-## Step 6: Persona Auto-Detection
+## Step 7: Persona Auto-Detection
 
 Read and follow `~/.claude/skill-references/persona-auto-detect.md`.
 
-## Step 7: Search Learnings for Domain Expertise
+## Step 8: Search Learnings for Domain Expertise
 
 Before exploring code, search for relevant learnings that provide gotchas, best practices, and domain patterns:
 
@@ -49,11 +49,11 @@ If no matches: `📚 [pre-implement] no matching learnings found`
 
 **Apply loaded learnings throughout implementation.** Treat them as constraints and best practices — they encode patterns the team has already validated. When a learning directly prevents a mistake or shapes a decision, note it briefly in your plan (step 9).
 
-## Step 8: Explore Relevant Code
+## Step 9: Explore Relevant Code
 
 Using the repo summary as a starting map, find the files that need modification. Read them. Understand existing patterns and conventions.
 
-## Step 9: Plan Changes
+## Step 10: Plan Changes
 
 Before writing code, state:
 - Which files you will modify/create
@@ -61,9 +61,9 @@ Before writing code, state:
 - How you will verify it works
 - Which learnings are shaping your approach (if any)
 
-## Step 10: Re-check Directives
+## Step 11: Re-check Directives
 
-Re-read `{RUN_DIR}/directives.md` and `{ISSUE_DIR}/directives.md` if they exist. The director may have written new directives since Step 2 (e.g., "post confirmation before implementing"). Incorporate any new instructions before proceeding.
+Re-read `{RUN_DIR}/directives.md` and `{ISSUE_DIR}/directives.md` if they exist. The director may have written new directives since Step 3 (e.g., "post confirmation before implementing"). Incorporate any new instructions before proceeding.
 
 ## Step 10b: Post Implementation Intent
 
@@ -87,11 +87,11 @@ COMMENT
 
 Make the changes. Follow existing code patterns and conventions. Keep changes minimal and focused on the work item.
 
-## Step 12: Test
+## Step 13: Test
 
 Run the project's test suite if available. If tests exist for the area you changed, ensure they pass. If no tests exist and the project has a test framework, consider adding a basic test.
 
-## Step 13: Git Workflow
+## Step 14: Git Workflow
 
 a. Rename your branch: `git branch -m sweep/{ISSUE_NUMBER}-<slug>`
    Derive slug from issue title: lowercase, hyphens, max 40 chars.
@@ -126,7 +126,7 @@ e. Create PR:
 - Do NOT modify files unrelated to the work item
 - Do NOT make architectural changes beyond what the work item requires
 
-## Step 14: Write Artifacts
+## Step 15: Write Artifacts
 
 ### result.md
 

--- a/claude/skill-references/persona-auto-detect.md
+++ b/claude/skill-references/persona-auto-detect.md
@@ -21,4 +21,10 @@ Select a domain persona by matching work item signals against available personas
 
 5. **Adopt or skip.** If the match fits, adopt its lens. If no filename resonates with the signals, proceed without a persona — don't force a weak match.
 
+6. **Resolve provider paths.** If the adopted persona contains `provider:<name>/path` references (in Proactive Cross-Refs, Cross-Refs, or inline):
+   1. Read `~/.claude/learnings-providers.json`
+   2. `provider:default/path` → find the entry with `"defaultWriteTarget": true`, use its `localPath/path`
+   3. `provider:<name>/path` → find the entry matching `"name"`, use its `localPath/path`
+   4. If the provider name isn't in the config, skip the reference and continue
+
 Announce: `🎭 Persona: <name>` or `🎭 No persona match — proceeding without`

--- a/claude/skill-references/sweep-agent-preflight.md
+++ b/claude/skill-references/sweep-agent-preflight.md
@@ -1,4 +1,4 @@
-**Step ordering note:** This shared preflight (Steps 1–5) sets `milestone: started` in Step 5. Role-specific steps use sequential numbering: clarifier/confirmer Step 6 (self-comment check) runs after preflight and may overwrite status to `skipped`; implementer Step 0 (git pre-flight) runs before preflight. Directors polling status.md may briefly see a `started` → `skipped` transition — this is intentional, and the window is sub-second within a single agent execution.
+**Step ordering note:** This shared preflight (Steps 1–6) sets `milestone: started` in Step 6. Role-specific steps use sequential numbering: clarifier/confirmer Step 7 (self-comment check) runs after preflight and may overwrite status to `skipped`; implementer Step 0 (git pre-flight) runs before preflight. Directors polling status.md may briefly see a `started` → `skipped` transition — this is intentional, and the window is sub-second within a single agent execution.
 
 
 ## Step 1: Permission Pre-flight
@@ -9,15 +9,24 @@ gh issue view {ISSUE_NUMBER} --json state -q '.state'
 ```
 If this fails with a permission error, write `milestone: errored` and `error: permission denied — gh` to `{ISSUE_DIR}/status.md` and exit immediately. This catches misconfigured `--allowedTools` early.
 
-## Step 2: Read Directives
+## Step 2: Resolve Provider Paths
+
+If any loaded content (persona files, learnings references, directives) contains `provider:<name>/path` references, resolve them:
+
+1. Read `~/.claude/learnings-providers.json`
+2. `provider:default/path` → find the entry with `"defaultWriteTarget": true`, use its `localPath/path`
+3. `provider:<name>/path` → find the entry matching `"name"`, use its `localPath/path`
+4. If the provider name isn't in the config, skip the reference and continue
+
+## Step 3: Read Directives
 
 Read `{RUN_DIR}/directives.md` and `{ISSUE_DIR}/directives.md` if they exist. These are instructions from the director — incorporate them into this pass. Directives may override skip logic, add focus areas, or provide context.
 
-## Step 3: Read Existing Watermark
+## Step 4: Read Existing Watermark
 
-If `{ISSUE_DIR}/status.md` exists, read `last_sweep_updated_at` and `last_comment_id`. If it doesn't exist, this is the first run — proceed to step 5.
+If `{ISSUE_DIR}/status.md` exists, read `last_sweep_updated_at` and `last_comment_id`. If it doesn't exist, this is the first run — proceed to step 6.
 
-## Step 4: Compare Against Current Issue State
+## Step 5: Compare Against Current Issue State
 
 Fetch the issue's current state and last comment body:
 ```bash
@@ -27,11 +36,11 @@ gh issue view {ISSUE_NUMBER} --json state,updatedAt,comments --jq '{state, updat
 **State check (earliest exit):** If state is `CLOSED`, set `milestone: skipped`, `issue_state: closed` in `{ISSUE_DIR}/status.md` and exit immediately.
 
 Compare against watermark values:
-- `updatedAt` differs OR `last_comment_id` differs → new activity, proceed to step 5
+- `updatedAt` differs OR `last_comment_id` differs → new activity, proceed to step 6
 - Both match AND no directives → no changes since last pass, set `milestone: skipped` in `{ISSUE_DIR}/status.md` and exit
-- Both match BUT directives present → directives override skip, proceed to step 5
+- Both match BUT directives present → directives override skip, proceed to step 6
 
-## Step 5: Update Status
+## Step 6: Update Status
 
 Write to `{ISSUE_DIR}/status.md`:
 ```yaml


### PR DESCRIPTION
## Summary
- Replace hardcoded `~/.claude/learnings-team/learnings/` paths with `provider:<name>/path` slugs across all 18 personas, 3 sweep prompts, and 2 skill references
- Update `set-persona` SKILL.md to resolve slugs via `learnings-providers.json` (provider lookup by name or `defaultWriteTarget`)
- Add provider resolution step to `persona-auto-detect.md` and `sweep-agent-preflight.md`
- Simplify permission patterns: `Read(~/.claude/learnings*/**)` covers all provider directories

## Test plan
- [x] Verified `provider:default/frontend/react-frontend-gotchas.md` resolves to `~/.claude/learnings/frontend/react-frontend-gotchas.md` via `/set-persona react-frontend`
- [x] Run `/set-persona java-backend` and confirm proactive cross-refs load
- [x] Run a sweep work-items pass and verify preflight resolves provider paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)