### PR TITLE
feat(director): codify decision-making framework

### DIFF
--- a/claude/commands/director/SKILL.md
+++ b/claude/commands/director/SKILL.md
@@ -49,7 +49,7 @@ For prompt-free execution, add these allow patterns to `~/.claude/settings.local
    }
    ```
    Indexed by item (`pr-69`, `issue-56`), not by run. Each item maps to an ordered list of run_dirs that touched it. Append-only — never update or remove entries. To check an item's status: read the last run_dir in its list, then read `<item-dir>/status.md`.
-7. Initialize an empty `decisions.md` in the session dir (append-only decision log per the playbook's Decision Framework). A single header line is enough:
+7. Initialize `decisions.md` in the session dir with a single header line (append-only decision log per the playbook's Decision Framework):
    ```markdown
    # Director Decisions — <timestamp>
    ```

--- a/claude/commands/director/SKILL.md
+++ b/claude/commands/director/SKILL.md
@@ -49,6 +49,10 @@ For prompt-free execution, add these allow patterns to `~/.claude/settings.local
    }
    ```
    Indexed by item (`pr-69`, `issue-56`), not by run. Each item maps to an ordered list of run_dirs that touched it. Append-only — never update or remove entries. To check an item's status: read the last run_dir in its list, then read `<item-dir>/status.md`.
+7. Initialize an empty `decisions.md` in the session dir (append-only decision log per the playbook's Decision Framework). A single header line is enough:
+   ```markdown
+   # Director Decisions — <timestamp>
+   ```
 
 ## Phase 2: Assess + Generate Artifacts
 
@@ -117,7 +121,7 @@ The director is event-driven, not polling. It reads state on-demand: when a back
 
 Note: process lifecycle (inactivity detection, kill, retry) is owned by the runner, not the director.
 
-**Escalation over automation**: when in doubt, present what you see, what you think it means, and what you'd recommend. The operator decides. As trust is established, the operator may cede more judgment -- respect the current escalation level.
+**Decision Framework**: follow the playbook's Decision Framework section (`~/.claude/skill-references/director-playbook.md`) for every judgment call. The escalation default has shifted — the director decides autonomously for routine/in-scope/taste-based calls, logs rationale to `<session_dir>/decisions.md` for dissent / cost-time / out-of-scope categories, and escalates to the operator only for irreversible, security, scope-expansion, intent-conflict, or external-surface actions. Out-of-scope review findings become GitHub issues (filed in the CWD repo), not operator pings. When escalating, still present what you see, what you think it means, and what you'd recommend.
 
 ## Phase 5: Convergence + Wrap-up
 
@@ -125,4 +129,5 @@ Note: process lifecycle (inactivity detection, kill, retry) is owned by the runn
 2. Session ends when all runs converge.
 3. Write final `director-state.md` per playbook format with terminal state.
 4. Present a final summary: per-run retro (read each run's `*/result.md` and `*/learnings.md`).
-5. Offer to invoke `/session-retro` if the session was substantial.
+5. Review `<session_dir>/decisions.md` as part of the retro — surface decide-with-report entries (dissent, cost-time, out-of-scope) so the operator can audit autonomous calls and flag any that should have been escalated.
+6. Offer to invoke `/session-retro` if the session was substantial.

--- a/claude/skill-references/director-playbook.md
+++ b/claude/skill-references/director-playbook.md
@@ -16,6 +16,51 @@ Structured guidance for the director (operator + main agent) when orchestrating 
 
 **Review and address must be separate `claude -p` sessions.** Never have the same agent both review and address an MR. A reviewer that knows it will also address goes easy; an addresser that wrote its own findings rubber-stamps them. The director presents review findings to the operator for sign-off before launching the address session. This is not a guideline — it is a structural requirement for review integrity.
 
+## Decision Framework
+
+The director has ceded decision power for routine calls but escalates on high-blast-radius, ambiguous-intent, or external-surface actions. Three tiers:
+
+### Escalate to operator (chat first, then log response)
+1. **Irreversible / high-blast-radius actions** — force-push to main, branch deletion, data drops, anything bypassing safety hooks. Operator pulls the trigger even when "obviously fine."
+2. **Scope expansion that changes PR intent** — pulling refactors into bug fixes, expanding a learnings PR into a skill rewrite. Small in-scope fixes are NOT escalated; out-of-scope discoveries are NOT escalated (see "Out-of-scope handling" below).
+3. **Security / auth / compliance touchpoints** — secrets, permission patterns, sensitive files, external credentials. Blast radius beyond the repo means the director can't fully reason about it.
+4. **Conflicting evidence about operator intent** — stated goal vs code signal disagree, or a request reads two ways with materially different outcomes. Escalate **with a written report** in `decisions.md` — not just a verbal ask.
+7. **External-facing surfaces** — PR titles/descriptions others read, public docs, anything landing beyond the operator/director loop.
+
+### Decide-with-report (director decides, logs rationale to `decisions.md`)
+5. **Subagent / reviewer dissent surviving deliberation** — two personas hold incompatible positions after a deliberation pass and the call is taste-based. Director makes the call and logs why.
+6. **Cost / time blowups** — sessions about to spawn many parallel agents, run for hours, or hit rate-limit cliffs. Director decides; reports estimated duration at launch and material deviations (>2x estimate) thereafter. No scheduled chatter — only deviation reports. Operator can checkpoint mid-session via chat.
+
+### Decide silently (no report needed)
+- Routine convergence calls in compound mode (deterministic per Convergence Rules).
+- Small in-scope fixes that match the PR's intent.
+- Choosing between equivalent technical paths.
+- Body discipline / formatting / template decisions.
+- Whether to write a directive for a summary-only finding inside the current scope.
+
+### Out-of-scope handling
+
+When a review surfaces a finding clearly outside the current PR's scope, the director:
+1. Files a GitHub issue in the CWD repo (or, in multi-repo sessions, the repo most relevant to the issue). Issue body includes: source PR/session reference, the finding text, suggested fix if any, and the persona that surfaced it.
+2. Logs the issue creation in `decisions.md` so the operator can audit what got punted.
+3. Optionally spawns `/sweep:work-items` to address immediately, **only if context window allows** (director discretion based on remaining tokens).
+
+### `decisions.md` schema
+
+Lives at `<session_dir>/decisions.md` alongside `session.json`. Append-only dated sections:
+
+```markdown
+## <ISO timestamp> — <one-line title>
+
+**Category**: <dissent | cost-time | out-of-scope | irreversible | scope-expansion | security | intent-conflict | external-surface>
+**Decision**: <what was decided>
+**Why**: <rationale, including what was weighed>
+**Reversal cost**: <how easy is this to undo>
+**Reported to operator**: <yes/no — yes for escalated categories, no for silent decide-with-report>
+```
+
+Write to `decisions.md` for all category 4/5/6 events. For categories 1/3/7, escalate to chat first, then log the operator's response.
+
 ## Prerequisites Checklist
 
 Before starting any sweep session:

--- a/claude/skill-references/director-playbook.md
+++ b/claude/skill-references/director-playbook.md
@@ -20,16 +20,16 @@ Structured guidance for the director (operator + main agent) when orchestrating 
 
 The director has ceded decision power for routine calls but escalates on high-blast-radius, ambiguous-intent, or external-surface actions. Three tiers:
 
-### Escalate to operator (chat first, then log response)
+### Escalate to operator (operator makes the call)
 1. **Irreversible / high-blast-radius actions** — force-push to main, branch deletion, data drops, anything bypassing safety hooks. Operator pulls the trigger even when "obviously fine."
 2. **Scope expansion that changes PR intent** — pulling refactors into bug fixes, expanding a learnings PR into a skill rewrite. Small in-scope fixes are NOT escalated; out-of-scope discoveries are NOT escalated (see "Out-of-scope handling" below).
 3. **Security / auth / compliance touchpoints** — secrets, permission patterns, sensitive files, external credentials. Blast radius beyond the repo means the director can't fully reason about it.
-4. **Conflicting evidence about operator intent** — stated goal vs code signal disagree, or a request reads two ways with materially different outcomes. Escalate **with a written report** in `decisions.md` — not just a verbal ask.
-7. **External-facing surfaces** — PR titles/descriptions others read, public docs, anything landing beyond the operator/director loop.
+4. **Conflicting evidence about operator intent** — stated goal vs code signal disagree, or a request reads two ways with materially different outcomes. Escalate **with a written report** in `decisions.md` — not just a verbal ask. (Written-report-first variant: log the report at escalation time, then chat.)
+5. **External-facing surfaces** — PR titles/descriptions others read, public docs, anything landing beyond the operator/director loop.
 
 ### Decide-with-report (director decides, logs rationale to `decisions.md`)
-5. **Subagent / reviewer dissent surviving deliberation** — two personas hold incompatible positions after a deliberation pass and the call is taste-based. Director makes the call and logs why.
-6. **Cost / time blowups** — sessions about to spawn many parallel agents, run for hours, or hit rate-limit cliffs. Director decides; reports estimated duration at launch and material deviations (>2x estimate) thereafter. No scheduled chatter — only deviation reports. Operator can checkpoint mid-session via chat.
+6. **Subagent / reviewer dissent surviving deliberation** — two personas hold incompatible positions after a deliberation pass and the call is taste-based. Director makes the call and logs why.
+7. **Cost / time blowups** — sessions about to spawn many parallel agents, run for hours, or hit rate-limit cliffs. Director decides; reports estimated duration at launch and material deviations (>2x estimate) thereafter. No scheduled chatter — only deviation reports. Operator can checkpoint mid-session via chat.
 
 ### Decide silently (no report needed)
 - Routine convergence calls in compound mode (deterministic per Convergence Rules).
@@ -56,10 +56,10 @@ Lives at `<session_dir>/decisions.md` alongside `session.json`. Append-only date
 **Decision**: <what was decided>
 **Why**: <rationale, including what was weighed>
 **Reversal cost**: <how easy is this to undo>
-**Reported to operator**: <yes/no — yes for escalated categories, no for silent decide-with-report>
+**Reported to operator**: <yes/no — yes for escalated categories, no for decide-with-report categories>
 ```
 
-Write to `decisions.md` for all category 4/5/6 events. For categories 1/3/7, escalate to chat first, then log the operator's response.
+Write to `decisions.md` at decision time for categories 4, 6, 7. For categories 1, 2, 3, 5, escalate to chat first and log the operator's response afterward.
 
 ## Prerequisites Checklist
 


### PR DESCRIPTION
Shifts the director's escalation default so routine, in-scope, and taste-based calls are decided autonomously. The playbook now carries a seven-category Decision Framework, a silent-decide list, out-of-scope issue-filing behavior, and a `decisions.md` schema for the append-only per-session decision log.

## Changes

- `claude/skill-references/director-playbook.md` — new `Decision Framework` section (after Director Principles) encoding escalate/decide-with-report/decide-silently tiers, out-of-scope handling, and `decisions.md` schema.
- `claude/commands/director/SKILL.md` — Phase 1 initializes `decisions.md`; Phase 4's escalation paragraph now points at the framework and calls out the shifted default; Phase 5 adds a `decisions.md` review step to the retro.

## Rationale

Operator ceded more decision power in a planning conversation. This encodes the agreed framework so future director sessions inherit it instead of re-negotiating escalation thresholds each run. The `decisions.md` log keeps autonomous calls auditable.