### PR TITLE
docs: deprecate cluster reference files (#83 — phase 2)

### DIFF
--- a/claude/skill-references/github/batch-operations.md
+++ b/claude/skill-references/github/batch-operations.md
@@ -1,8 +1,8 @@
 ---
-description: "GitHub commands for batch PR metadata fetching (used by extract-request-learnings)."
+description: "DEPRECATED — Commands extracted to commands/*.sh files. Retained as human-readable reference."
 ---
 
-# GitHub: Batch Operations
+# GitHub: Batch Operations (Deprecated — see commands/)
 
 **Use these templates verbatim** — substitute placeholders but don't simplify, reformat, or drop parameters.
 

--- a/claude/skill-references/github/comment-interaction.md
+++ b/claude/skill-references/github/comment-interaction.md
@@ -1,8 +1,8 @@
 ---
-description: "GitHub commands for fetching, posting, and reacting to PR comments."
+description: "DEPRECATED — Commands extracted to commands/*.sh files. Retained as human-readable reference."
 ---
 
-# GitHub: Comment Interaction
+# GitHub: Comment Interaction (Deprecated — see commands/)
 
 **Important:** Never use `!=` in jq expressions passed via `gh --jq` — the `!` gets shell-escaped. Use positive equivalents like `select(.body | length > 0)`.
 

--- a/claude/skill-references/github/fetch-review-data.md
+++ b/claude/skill-references/github/fetch-review-data.md
@@ -1,8 +1,8 @@
 ---
-description: "GitHub commands for fetching PR metadata, diffs, files, and commits."
+description: "DEPRECATED — Commands extracted to commands/*.sh files. Retained as human-readable reference."
 ---
 
-# GitHub: Fetch Review Data
+# GitHub: Fetch Review Data (Deprecated — see commands/)
 
 **Use these templates verbatim** — substitute placeholders but don't simplify, reformat, or drop parameters.
 

--- a/claude/skill-references/github/issue-operations.md
+++ b/claude/skill-references/github/issue-operations.md
@@ -1,8 +1,8 @@
 ---
-description: "GitHub commands for listing issues, fetching details, posting comments, and checking linked PRs."
+description: "DEPRECATED — Commands extracted to commands/*.sh files. Retained as human-readable reference."
 ---
 
-# GitHub: Issue Operations
+# GitHub: Issue Operations (Deprecated — see commands/)
 
 **Use these templates verbatim** — substitute placeholders but don't simplify, reformat, or drop parameters.
 

--- a/claude/skill-references/github/pr-management.md
+++ b/claude/skill-references/github/pr-management.md
@@ -1,8 +1,10 @@
 ---
-description: "GitHub commands for creating/updating PRs, posting reviews, and branch management."
+description: "DEPRECATED — Commands extracted to commands/*.sh files. Retained as human-readable reference."
 ---
 
-# GitHub: PR Management
+# GitHub: PR Management (Deprecated — see commands/)
+
+> **Note:** Skills no longer load this file. Commands have been extracted to atomic `.sh` files in `commands/` and are inlined via `!` preprocessing. This file is retained as human-readable reference.
 
 **Use these templates verbatim** — substitute placeholders but don't simplify, reformat, or drop parameters.
 

--- a/claude/skill-references/github/pr-management.md
+++ b/claude/skill-references/github/pr-management.md
@@ -4,7 +4,7 @@ description: "DEPRECATED — Commands extracted to commands/*.sh files. Retained
 
 # GitHub: PR Management (Deprecated — see commands/)
 
-> **Note:** Skills no longer load this file. Commands have been extracted to atomic `.sh` files in `commands/` and are inlined via `!` preprocessing. This file is retained as human-readable reference.
+> **Note:** Skills are being migrated away from this file. Commands have been extracted to atomic `.sh` files in `commands/` and are inlined via `!` preprocessing. This file is retained as human-readable reference until migration is complete.
 
 **Use these templates verbatim** — substitute placeholders but don't simplify, reformat, or drop parameters.
 

--- a/claude/skill-references/gitlab/batch-operations.md
+++ b/claude/skill-references/gitlab/batch-operations.md
@@ -1,8 +1,8 @@
 ---
-description: "GitLab commands for batch MR metadata fetching (used by extract-request-learnings)."
+description: "DEPRECATED — Commands extracted to commands/*.sh files. Retained as human-readable reference."
 ---
 
-# GitLab: Batch Operations
+# GitLab: Batch Operations (Deprecated — see commands/)
 
 **Use these templates verbatim** — substitute placeholders but don't simplify, reformat, or drop parameters.
 

--- a/claude/skill-references/gitlab/comment-interaction.md
+++ b/claude/skill-references/gitlab/comment-interaction.md
@@ -1,8 +1,8 @@
 ---
-description: "GitLab commands for fetching, posting, and reacting to MR comments."
+description: "DEPRECATED — Commands extracted to commands/*.sh files. Retained as human-readable reference."
 ---
 
-# GitLab: Comment Interaction
+# GitLab: Comment Interaction (Deprecated — see commands/)
 
 **Important:** Never use `!=` in jq expressions passed via `glab --jq` — the `!` gets shell-escaped. Use positive equivalents like `select(.body | length > 0)`.
 

--- a/claude/skill-references/gitlab/fetch-review-data.md
+++ b/claude/skill-references/gitlab/fetch-review-data.md
@@ -1,8 +1,8 @@
 ---
-description: "GitLab commands for fetching MR metadata, diffs, files, and commits."
+description: "DEPRECATED — Commands extracted to commands/*.sh files. Retained as human-readable reference."
 ---
 
-# GitLab: Fetch Review Data
+# GitLab: Fetch Review Data (Deprecated — see commands/)
 
 **Use these templates verbatim** — substitute placeholders but don't simplify, reformat, or drop parameters.
 

--- a/claude/skill-references/gitlab/issue-operations.md
+++ b/claude/skill-references/gitlab/issue-operations.md
@@ -1,8 +1,8 @@
 ---
-description: "GitLab commands for listing issues, fetching details, and posting comments. (v2 stub — not yet implemented)"
+description: "DEPRECATED — Commands extracted to commands/*.sh files. Retained as human-readable reference."
 ---
 
-# GitLab: Issue Operations
+# GitLab: Issue Operations (Deprecated — see commands/)
 
 Placeholder for GitLab issue provider. Implementation deferred to v2.
 

--- a/claude/skill-references/gitlab/pr-management.md
+++ b/claude/skill-references/gitlab/pr-management.md
@@ -4,6 +4,8 @@ description: "DEPRECATED — Commands extracted to commands/*.sh files. Retained
 
 # GitLab: MR Management (Deprecated — see commands/)
 
+> **Note:** Skills are being migrated away from this file. Commands have been extracted to atomic `.sh` files in `commands/` and are inlined via `!` preprocessing. This file is retained as human-readable reference until migration is complete.
+
 **Use these templates verbatim** — substitute placeholders but don't simplify, reformat, or drop parameters.
 
 ## Create or Update MR (Body via File)

--- a/claude/skill-references/gitlab/pr-management.md
+++ b/claude/skill-references/gitlab/pr-management.md
@@ -1,8 +1,8 @@
 ---
-description: "GitLab commands for creating/updating MRs, posting reviews, and branch management."
+description: "DEPRECATED — Commands extracted to commands/*.sh files. Retained as human-readable reference."
 ---
 
-# GitLab: MR Management
+# GitLab: MR Management (Deprecated — see commands/)
 
 **Use these templates verbatim** — substitute placeholders but don't simplify, reformat, or drop parameters.
 

--- a/claude/skill-references/platform-detection.md
+++ b/claude/skill-references/platform-detection.md
@@ -1,8 +1,10 @@
 ---
-description: "Internal reference — GitHub vs GitLab detection logic. Used by git skills, not invoked directly."
+description: "DEPRECATED — Platform is now resolved at setup time via setup-claude.sh. Skills use !`cat ~/.claude/platform-commands/<cmd>.sh` instead. Retained as fallback for subagent sessions that lack the symlink."
 ---
 
-# Platform Detection
+# Platform Detection (Deprecated)
+
+> **Note:** Skills no longer read this file. Platform commands are inlined via `!` preprocessing from `~/.claude/platform-commands/` (a symlink to the correct platform's `commands/` directory, created by `setup-claude.sh`). This file is retained only as a fallback for `claude -p` subagent sessions that may not have the symlink.
 
 Before executing any platform-specific commands, detect whether the repository uses GitHub or GitLab.
 

--- a/claude/skill-references/platform-detection.md
+++ b/claude/skill-references/platform-detection.md
@@ -4,7 +4,7 @@ description: "DEPRECATED — Platform is now resolved at setup time via setup-cl
 
 # Platform Detection (Deprecated)
 
-> **Note:** Skills no longer read this file. Platform commands are inlined via `!` preprocessing from `~/.claude/platform-commands/` (a symlink to the correct platform's `commands/` directory, created by `setup-claude.sh`). This file is retained only as a fallback for `claude -p` subagent sessions that may not have the symlink.
+> **Note:** Skills are being migrated away from this file. Platform commands are inlined via `!` preprocessing from `~/.claude/platform-commands/` (a symlink to the correct platform's `commands/` directory, created by `setup-claude.sh`). This file is retained only as a fallback for `claude -p` subagent sessions that may not have the symlink.
 
 Before executing any platform-specific commands, detect whether the repository uses GitHub or GitLab.
 


### PR DESCRIPTION
## Summary

- Marks old cluster `.md` reference files (pr-management, comment-interaction, fetch-review-data, issue-operations, batch-operations) and `platform-detection.md` as deprecated via frontmatter notes
- Files retained as human-readable reference — removal happens after the new `.sh` command pattern is validated
- Both GitHub and GitLab platform clusters updated

Relates to https://github.com/ahoym/dotfiles/issues/83

## Test plan

- [ ] Verify deprecation notes appear in frontmatter of all 11 files
- [ ] Confirm no content was removed from any file
- [ ] Skills that reference these files still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)