### PR TITLE
feat: extract .sh platform command files (#83 — phase 1)

### DIFF
--- a/claude/skill-references/github/commands/batch-fetch-reviews.sh
+++ b/claude/skill-references/github/commands/batch-fetch-reviews.sh
@@ -1,0 +1,5 @@
+# Write jq filter to tmp/claude-artifacts/jq-filters/jq-filter.jq via Write tool first:
+#   .[] | {number, title, state, comments, user: .user.login, head_branch: .head.ref, requested_reviewers: [.requested_reviewers[].login], created_at: .created_at[:10], merged_at: (.merged_at // "n/a")[:10], body: (.body // "(none)")[:400]}
+# Then:
+gh api 'repos/{owner}/{repo}/pulls?state=all&sort=created&direction=asc&per_page=<SIZE>&page=<PAGE>' \
+  | jq -cf tmp/claude-artifacts/jq-filters/jq-filter.jq

--- a/claude/skill-references/github/commands/check-existing-review.sh
+++ b/claude/skill-references/github/commands/check-existing-review.sh
@@ -1,0 +1,1 @@
+gh pr list --head <branch-name>

--- a/claude/skill-references/github/commands/checkout-review.sh
+++ b/claude/skill-references/github/commands/checkout-review.sh
@@ -1,0 +1,2 @@
+gh pr checkout <number>
+git pull origin <headRefName>

--- a/claude/skill-references/github/commands/consolidated-fetch.sh
+++ b/claude/skill-references/github/commands/consolidated-fetch.sh
@@ -1,0 +1,3 @@
+# Fetch state + reviews + top-level comments in a single call.
+# No --jq (avoids quoted string permission prompts).
+gh pr view <number> --json state,reviews,comments,number,title,headRefName,baseRefName

--- a/claude/skill-references/github/commands/count-total-reviews.sh
+++ b/claude/skill-references/github/commands/count-total-reviews.sh
@@ -1,0 +1,1 @@
+gh api 'repos/{owner}/{repo}/pulls?state=all&per_page=1' -i 2>&1 | grep -i 'link:'

--- a/claude/skill-references/github/commands/create-review.sh
+++ b/claude/skill-references/github/commands/create-review.sh
@@ -1,0 +1,2 @@
+# Write body via Write tool to tmp/claude-artifacts/change-request-replies/pr-body.md, then:
+gh pr create --base <base-branch> --title "<title>" --body-file tmp/claude-artifacts/change-request-replies/pr-body.md

--- a/claude/skill-references/github/commands/fetch-activity-signals.sh
+++ b/claude/skill-references/github/commands/fetch-activity-signals.sh
@@ -1,0 +1,3 @@
+# Quick-exit check for polling — commits, reviews, state, and top-level comments in one call.
+# No --jq. Parse JSON response in agent logic.
+gh pr view <number> --json commits,reviews,state,comments

--- a/claude/skill-references/github/commands/fetch-inline-comments.sh
+++ b/claude/skill-references/github/commands/fetch-inline-comments.sh
@@ -1,0 +1,8 @@
+# Full fetch (--paginate to get all comments beyond default 30-per-page limit)
+gh api repos/{owner}/{repo}/pulls/<number>/comments --paginate --jq '.[] | {id, path, line, body, user: .user.login, created_at}'
+
+# Incremental fetch — write jq filter to file first:
+# 1. Write to tmp/claude-artifacts/jq-filters/jq-filter.jq via Write tool:
+#      .[] | select(.created_at > "<TS>") | {id, path, line, body, user: .user.login, created_at}
+# 2. Then (use piped jq -f instead of --jq):
+# gh api repos/{owner}/{repo}/pulls/<number>/comments --paginate | jq -f tmp/claude-artifacts/jq-filters/jq-filter.jq

--- a/claude/skill-references/github/commands/fetch-issue-comments.sh
+++ b/claude/skill-references/github/commands/fetch-issue-comments.sh
@@ -1,0 +1,8 @@
+# Full fetch (--paginate to get all comments beyond default 30-per-page limit)
+gh api repos/{owner}/{repo}/issues/<number>/comments --paginate --jq '.[] | {id, body, user: .user.login, created_at}'
+
+# Incremental fetch — write jq filter to file first:
+# 1. Write to tmp/claude-artifacts/jq-filters/jq-filter.jq via Write tool:
+#      .[] | select(.created_at > "<TS>") | {id, body, user: .user.login, created_at}
+# 2. Then (use piped jq -f instead of --jq):
+# gh api repos/{owner}/{repo}/issues/<number>/comments --paginate | jq -f tmp/claude-artifacts/jq-filters/jq-filter.jq

--- a/claude/skill-references/github/commands/fetch-issue.sh
+++ b/claude/skill-references/github/commands/fetch-issue.sh
@@ -1,0 +1,1 @@
+gh issue view <NUMBER> --json number,title,body,labels,assignees,comments,url

--- a/claude/skill-references/github/commands/fetch-recent-inline-comments.sh
+++ b/claude/skill-references/github/commands/fetch-recent-inline-comments.sh
@@ -1,0 +1,3 @@
+# Quick-exit check for polling. Fetches 10 to see past agent replies. No --jq.
+gh api repos/{owner}/{repo}/pulls/<number>/comments --method GET -f sort=created -f direction=desc -F per_page=10
+# Filter out self-comments (Role:.*<YOUR_ROLE> in body).

--- a/claude/skill-references/github/commands/fetch-review-comments.sh
+++ b/claude/skill-references/github/commands/fetch-review-comments.sh
@@ -1,0 +1,2 @@
+gh pr view <number> --json reviews --jq '.reviews[] | select(.body | length > 0) | {author: .author.login, state: .state, body}'
+# No since filtering. On incremental fetches, compare count against LAST_REVIEW_COUNT.

--- a/claude/skill-references/github/commands/fetch-review-commits.sh
+++ b/claude/skill-references/github/commands/fetch-review-commits.sh
@@ -1,0 +1,2 @@
+gh pr view <number> --json commits \
+  --jq '.commits[] | {sha: .oid[0:7], message: .messageHeadline}'

--- a/claude/skill-references/github/commands/fetch-review-details.sh
+++ b/claude/skill-references/github/commands/fetch-review-details.sh
@@ -1,0 +1,1 @@
+gh pr view <number> --json number,title,headRefName,baseRefName,url,state

--- a/claude/skill-references/github/commands/fetch-review-diff.sh
+++ b/claude/skill-references/github/commands/fetch-review-diff.sh
@@ -1,0 +1,1 @@
+gh pr diff <number>

--- a/claude/skill-references/github/commands/fetch-review-files.sh
+++ b/claude/skill-references/github/commands/fetch-review-files.sh
@@ -1,0 +1,1 @@
+gh pr view <number> --json files --jq '.files[].path'

--- a/claude/skill-references/github/commands/find-approved-reviewers.sh
+++ b/claude/skill-references/github/commands/find-approved-reviewers.sh
@@ -1,0 +1,5 @@
+# Write jq filter to tmp/claude-artifacts/jq-filters/jq-filter.jq via Write tool first:
+#   [.[] | select(.state == "APPROVED") | .user.login] | unique | .[]
+# Then (use piped jq -f instead of --jq):
+gh api repos/{owner}/{repo}/pulls/<number>/reviews \
+  | jq -rf tmp/claude-artifacts/jq-filters/jq-filter.jq

--- a/claude/skill-references/github/commands/list-open-issues.sh
+++ b/claude/skill-references/github/commands/list-open-issues.sh
@@ -1,0 +1,5 @@
+# All open issues (default limit 30)
+gh issue list --state open --json number,title,body,labels,assignees --limit <LIMIT>
+
+# Filtered by label (repeat --label for multiple, AND logic):
+# gh issue list --state open --label <LABEL> --json number,title,body,labels,assignees --limit <LIMIT>

--- a/claude/skill-references/github/commands/post-issue-comment.sh
+++ b/claude/skill-references/github/commands/post-issue-comment.sh
@@ -1,0 +1,3 @@
+# Write body via Write tool to tmp/claude-artifacts/sweep-work-items/clarify-<NUMBER>.md, then:
+# Use absolute paths — gh resolves file paths relative to CWD.
+gh issue comment <NUMBER> --body-file /absolute/path/to/tmp/claude-artifacts/sweep-work-items/clarify-<NUMBER>.md

--- a/claude/skill-references/github/commands/post-review-comments.sh
+++ b/claude/skill-references/github/commands/post-review-comments.sh
@@ -1,0 +1,11 @@
+# Write JSON payload to tmp/claude-artifacts/change-request-replies/review-<number>.json, then:
+gh api repos/{owner}/{repo}/pulls/<number>/reviews \
+  --input tmp/claude-artifacts/change-request-replies/review-<number>.json
+# Clean up:
+rm tmp/claude-artifacts/change-request-replies/review-<number>.json
+
+# Payload format (tmp/claude-artifacts/change-request-replies/review-<number>.json):
+# {"event": "COMMENT", "body": "...", "comments": [{"path": "file.md", "line": 42, "side": "RIGHT", "body": "..."}]}
+# event: COMMENT, APPROVE, or REQUEST_CHANGES
+# line: line number in final version (RIGHT side of diff)
+# side: always RIGHT for new-version comments

--- a/claude/skill-references/github/commands/post-review-comments.sh
+++ b/claude/skill-references/github/commands/post-review-comments.sh
@@ -1,7 +1,7 @@
 # Write JSON payload to tmp/claude-artifacts/change-request-replies/review-<number>.json, then:
 gh api repos/{owner}/{repo}/pulls/<number>/reviews \
   --input tmp/claude-artifacts/change-request-replies/review-<number>.json
-# Clean up:
+# Optional: clean up payload after posting
 rm tmp/claude-artifacts/change-request-replies/review-<number>.json
 
 # Payload format (tmp/claude-artifacts/change-request-replies/review-<number>.json):

--- a/claude/skill-references/github/commands/post-top-level-comment.sh
+++ b/claude/skill-references/github/commands/post-top-level-comment.sh
@@ -1,0 +1,3 @@
+# Write body to tmp/claude-artifacts/change-request-replies/<pr_number>-<persona>-<role>-top.md, then:
+# Use absolute paths — same CWD caveat as reply-to-inline-comment.
+gh pr comment <number> --body-file /absolute/path/to/tmp/claude-artifacts/change-request-replies/<pr_number>-<persona>-<role>-top.md

--- a/claude/skill-references/github/commands/react-to-comment.sh
+++ b/claude/skill-references/github/commands/react-to-comment.sh
@@ -1,0 +1,6 @@
+# React to inline/review comment (available: +1, -1, laugh, confused, heart, hooray, rocket, eyes)
+# Use -f (lowercase) not -F — -F infers type and treats +1/-1 as numeric, which the API rejects
+gh api repos/{owner}/{repo}/pulls/comments/<comment_id>/reactions -f content=<emoji>
+
+# React to issue/top-level comment:
+# gh api repos/{owner}/{repo}/issues/comments/<comment_id>/reactions -f content=<emoji>

--- a/claude/skill-references/github/commands/reply-to-inline-comment.sh
+++ b/claude/skill-references/github/commands/reply-to-inline-comment.sh
@@ -1,0 +1,4 @@
+# Write body to tmp/claude-artifacts/change-request-replies/<comment_id>-<persona>-<role>.md, then:
+# Use absolute paths with -F body=@ — gh api resolves @ paths relative to CWD.
+gh api repos/{owner}/{repo}/pulls/<number>/comments \
+  -F body=@/absolute/path/to/tmp/claude-artifacts/change-request-replies/<comment_id>-<persona>-<role>.md -F in_reply_to=<comment_id>

--- a/claude/skill-references/github/commands/update-review.sh
+++ b/claude/skill-references/github/commands/update-review.sh
@@ -1,0 +1,2 @@
+# Write body via Write tool to tmp/claude-artifacts/change-request-replies/pr-body.md, then:
+gh pr edit <number> --body-file tmp/claude-artifacts/change-request-replies/pr-body.md

--- a/claude/skill-references/github/commands/verify-platform-access.sh
+++ b/claude/skill-references/github/commands/verify-platform-access.sh
@@ -1,0 +1,1 @@
+gh api 'repos/{owner}/{repo}/pulls?state=all&per_page=1' | jq length

--- a/claude/skill-references/gitlab/commands/batch-fetch-reviews.sh
+++ b/claude/skill-references/gitlab/commands/batch-fetch-reviews.sh
@@ -1,0 +1,5 @@
+# Write jq filter to tmp/claude-artifacts/jq-filters/jq-filter.jq via Write tool first:
+#   .[] | {iid, title, state, user_notes_count, author: .author.username, source_branch, reviewers: [.reviewers[].username], created_at: .created_at[:10], merged_at: (.merged_at // "n/a")[:10], description: (.description // "(none)")[:400]}
+# Then:
+glab api "projects/:id/merge_requests?state=all&sort=asc&order_by=created_at&per_page=<SIZE>&page=<PAGE>" \
+  | jq -cf tmp/claude-artifacts/jq-filters/jq-filter.jq

--- a/claude/skill-references/gitlab/commands/check-existing-review.sh
+++ b/claude/skill-references/gitlab/commands/check-existing-review.sh
@@ -1,0 +1,1 @@
+glab mr list --source-branch <branch-name>

--- a/claude/skill-references/gitlab/commands/checkout-review.sh
+++ b/claude/skill-references/gitlab/commands/checkout-review.sh
@@ -1,0 +1,2 @@
+glab mr checkout <number>
+git pull origin <source_branch>

--- a/claude/skill-references/gitlab/commands/consolidated-fetch.sh
+++ b/claude/skill-references/gitlab/commands/consolidated-fetch.sh
@@ -1,0 +1,2 @@
+# Fetch state + metadata in a single call. Includes discussions with -c flag.
+glab mr view <number> -F json -c

--- a/claude/skill-references/gitlab/commands/count-total-reviews.sh
+++ b/claude/skill-references/gitlab/commands/count-total-reviews.sh
@@ -1,0 +1,1 @@
+glab api "projects/:id/merge_requests?state=all&per_page=1" --include 2>&1 | grep -i x-total

--- a/claude/skill-references/gitlab/commands/create-review.sh
+++ b/claude/skill-references/gitlab/commands/create-review.sh
@@ -1,0 +1,3 @@
+# Write body via Write tool to tmp/claude-artifacts/change-request-replies/request-body-<BRANCH_NAME>.md, then:
+# Use absolute paths with $(cat) — resolves relative to CWD.
+glab mr create --target-branch <base-branch> --title "<title>" --description "$(cat /absolute/path/to/tmp/claude-artifacts/change-request-replies/request-body-<BRANCH_NAME>.md)"

--- a/claude/skill-references/gitlab/commands/fetch-activity-signals.sh
+++ b/claude/skill-references/gitlab/commands/fetch-activity-signals.sh
@@ -1,0 +1,3 @@
+# Quick-exit check for polling — MR state and latest activity.
+# For notes/comments activity, see fetch-recent-inline-comments.sh.
+glab mr view <number> --output json

--- a/claude/skill-references/gitlab/commands/fetch-inline-comments.sh
+++ b/claude/skill-references/gitlab/commands/fetch-inline-comments.sh
@@ -1,0 +1,8 @@
+# Full fetch (--paginate to get all notes beyond default page limit)
+glab api projects/:id/merge_requests/<number>/notes --paginate | jq '.[] | {id, body, author: .author.username, created_at, position}'
+
+# Incremental fetch — write jq filter to file first:
+# 1. Write to tmp/claude-artifacts/jq-filters/jq-filter.jq via Write tool:
+#      .[] | select(.created_at > "<TS>") | {id, body, author: .author.username, created_at, position}
+# 2. Then:
+# glab api projects/:id/merge_requests/<number>/notes --paginate | jq -f tmp/claude-artifacts/jq-filters/jq-filter.jq

--- a/claude/skill-references/gitlab/commands/fetch-issue-comments.sh
+++ b/claude/skill-references/gitlab/commands/fetch-issue-comments.sh
@@ -1,0 +1,8 @@
+# Full fetch — notes without position data are top-level comments
+glab api projects/:id/merge_requests/<number>/notes --paginate | jq '[.[] | select(.position == null)] | .[] | {id, body, author: .author.username, created_at}'
+
+# Incremental fetch — write jq filter to file first:
+# 1. Write to tmp/claude-artifacts/jq-filters/jq-filter.jq via Write tool:
+#      [.[] | select(.position == null)] | .[] | select(.created_at > "<TS>") | {id, body, author: .author.username, created_at}
+# 2. Then:
+# glab api projects/:id/merge_requests/<number>/notes --paginate | jq -f tmp/claude-artifacts/jq-filters/jq-filter.jq

--- a/claude/skill-references/gitlab/commands/fetch-issue.sh
+++ b/claude/skill-references/gitlab/commands/fetch-issue.sh
@@ -1,0 +1,2 @@
+# GitLab issue operations (v2 stub — not fully implemented)
+glab issue view <IID>

--- a/claude/skill-references/gitlab/commands/fetch-recent-inline-comments.sh
+++ b/claude/skill-references/gitlab/commands/fetch-recent-inline-comments.sh
@@ -1,0 +1,3 @@
+# Quick-exit check for polling. Fetches 10 to see past agent replies.
+glab api projects/:id/merge_requests/<number>/notes --method GET -f sort=desc -F per_page=10
+# Filter out self-comments (Role:.*<YOUR_ROLE> in body).

--- a/claude/skill-references/gitlab/commands/fetch-review-comments.sh
+++ b/claude/skill-references/gitlab/commands/fetch-review-comments.sh
@@ -1,0 +1,4 @@
+# Use discussions endpoint for threaded comments
+glab api projects/:id/merge_requests/<number>/discussions \
+  | jq '.[] | {id, notes: [.notes[] | {id, body, author: .author.username, position}]}'
+# No updated_after filtering. On incremental fetches, compare discussion count against LAST_REVIEW_COUNT.

--- a/claude/skill-references/gitlab/commands/fetch-review-commits.sh
+++ b/claude/skill-references/gitlab/commands/fetch-review-commits.sh
@@ -1,0 +1,3 @@
+# glab api has no --jq flag. Pipe to standalone jq instead.
+glab api projects/:id/merge_requests/<number>/commits \
+  | jq '.[] | {sha: .short_id, message: .title}'

--- a/claude/skill-references/gitlab/commands/fetch-review-details.sh
+++ b/claude/skill-references/gitlab/commands/fetch-review-details.sh
@@ -1,0 +1,1 @@
+glab mr view <number> --output json

--- a/claude/skill-references/gitlab/commands/fetch-review-diff.sh
+++ b/claude/skill-references/gitlab/commands/fetch-review-diff.sh
@@ -1,0 +1,1 @@
+glab mr diff <number>

--- a/claude/skill-references/gitlab/commands/fetch-review-files.sh
+++ b/claude/skill-references/gitlab/commands/fetch-review-files.sh
@@ -1,0 +1,2 @@
+# Uses MR changes API instead of parsing raw diff — avoids quoted grep/sed args.
+glab api projects/:id/merge_requests/<number>/changes | jq -r .changes[].new_path

--- a/claude/skill-references/gitlab/commands/find-approved-reviewers.sh
+++ b/claude/skill-references/gitlab/commands/find-approved-reviewers.sh
@@ -1,0 +1,5 @@
+# Write jq filter to tmp/claude-artifacts/jq-filters/jq-filter.jq via Write tool first:
+#   [.[] | select(.body | test("LGTM"; "i"))] | [.[].author.username] | unique | .[]
+# Then:
+glab api "projects/:id/merge_requests/<number>/notes?sort=desc&per_page=100" \
+  | jq -rf tmp/claude-artifacts/jq-filters/jq-filter.jq

--- a/claude/skill-references/gitlab/commands/list-open-issues.sh
+++ b/claude/skill-references/gitlab/commands/list-open-issues.sh
@@ -1,0 +1,2 @@
+# GitLab issue operations (v2 stub — not fully implemented)
+glab issue list --state opened

--- a/claude/skill-references/gitlab/commands/post-issue-comment.sh
+++ b/claude/skill-references/gitlab/commands/post-issue-comment.sh
@@ -1,0 +1,2 @@
+# GitLab issue operations (v2 stub — not fully implemented)
+glab issue note <IID> --message-file <path>

--- a/claude/skill-references/gitlab/commands/post-issue-comment.sh
+++ b/claude/skill-references/gitlab/commands/post-issue-comment.sh
@@ -1,2 +1,2 @@
 # GitLab issue operations (v2 stub — not fully implemented)
-glab issue note <IID> --message-file <path>
+glab issue note <IID> -m "$(cat <path>)"

--- a/claude/skill-references/gitlab/commands/post-review-comments.sh
+++ b/claude/skill-references/gitlab/commands/post-review-comments.sh
@@ -9,6 +9,7 @@
 # For complex mutations, write query to .graphql file and use uppercase -F:
 #   glab api graphql -F query=@tmp/claude-artifacts/change-request-replies/gql-1.graphql
 # Lowercase -f query=@file does NOT read the file — passes literal "@file" string.
+# Alternatively, inline the mutation directly (lowercase -f with literal string):
 glab api graphql -f query='mutation {
   createDiffNote(input: {
     noteableId: "gid://gitlab/MergeRequest/<mr_id>",

--- a/claude/skill-references/gitlab/commands/post-review-comments.sh
+++ b/claude/skill-references/gitlab/commands/post-review-comments.sh
@@ -1,0 +1,29 @@
+# GitLab has no single review API. Post inline comments via GraphQL, then summary as top-level comment.
+
+# Step 1: Get SHAs and MR internal ID:
+# glab api projects/:id/merge_requests/<number>/versions | jq '.[0] | {base_commit_sha, head_commit_sha}'
+# glab mr view <number> --output json | jq '.id'
+# The MR id (not iid) is needed for GraphQL noteableId: "gid://gitlab/MergeRequest/<id>"
+
+# Step 2: Post each inline comment via GraphQL:
+# For complex mutations, write query to .graphql file and use uppercase -F:
+#   glab api graphql -F query=@tmp/claude-artifacts/change-request-replies/gql-1.graphql
+# Lowercase -f query=@file does NOT read the file — passes literal "@file" string.
+glab api graphql -f query='mutation {
+  createDiffNote(input: {
+    noteableId: "gid://gitlab/MergeRequest/<mr_id>",
+    body: "<escaped_body>",
+    position: {
+      baseSha: "<base_sha>",
+      headSha: "<head_sha>",
+      startSha: "<base_sha>",
+      paths: { oldPath: "<file_path>", newPath: "<file_path>" },
+      newLine: <line_number>
+    }
+  }) { note { id } errors }
+}'
+
+# Body escaping: use jq -Rs on a file for JSON-escaped string. Always jq, never python3.
+# Line number: must match exact line in new file (1-indexed). Verify against file content, not diff hunk arithmetic.
+# For new lines (+): omit oldLine. Context lines: both oldLine and newLine. Removed lines (-): only oldLine.
+# Step 3: Post review summary as top-level comment (see post-top-level-comment.sh).

--- a/claude/skill-references/gitlab/commands/post-top-level-comment.sh
+++ b/claude/skill-references/gitlab/commands/post-top-level-comment.sh
@@ -1,0 +1,5 @@
+# Write body to tmp/claude-artifacts/change-request-replies/<mr_number>-<persona>-<role>-top.md, then:
+# Use absolute paths with -F body=@ — glab api resolves @ paths relative to CWD.
+# Avoid glab mr comment --message "$(cat ...)" — $(cat) triggers permission prompts.
+glab api projects/:id/merge_requests/<number>/notes -X POST \
+  -F body=@/absolute/path/to/tmp/claude-artifacts/change-request-replies/<mr_number>-<persona>-<role>-top.md

--- a/claude/skill-references/gitlab/commands/react-to-comment.sh
+++ b/claude/skill-references/gitlab/commands/react-to-comment.sh
@@ -1,0 +1,2 @@
+# React to a merge request note (available: thumbsup, thumbsdown, smile, tada, confused, heart, rocket, eyes)
+glab api projects/:id/merge_requests/<number>/notes/<note_id>/award_emoji -X POST -F name=<emoji>

--- a/claude/skill-references/gitlab/commands/reply-to-inline-comment.sh
+++ b/claude/skill-references/gitlab/commands/reply-to-inline-comment.sh
@@ -1,0 +1,4 @@
+# Write body to tmp/claude-artifacts/change-request-replies/<note_id>-<persona>-<role>.md, then:
+# Use absolute paths with -F body=@ — glab api resolves @ paths relative to CWD.
+glab api projects/:id/merge_requests/<number>/discussions/<discussion_id>/notes \
+  -X POST -F body=@/absolute/path/to/tmp/claude-artifacts/change-request-replies/<note_id>-<persona>-<role>.md

--- a/claude/skill-references/gitlab/commands/update-review.sh
+++ b/claude/skill-references/gitlab/commands/update-review.sh
@@ -1,0 +1,3 @@
+# Write body via Write tool to tmp/claude-artifacts/change-request-replies/request-body-<BRANCH_NAME>.md, then:
+# Use absolute paths with $(cat) — resolves relative to CWD.
+glab mr update <number> --description "$(cat /absolute/path/to/tmp/claude-artifacts/change-request-replies/request-body-<BRANCH_NAME>.md)"

--- a/claude/skill-references/gitlab/commands/verify-platform-access.sh
+++ b/claude/skill-references/gitlab/commands/verify-platform-access.sh
@@ -1,0 +1,1 @@
+glab api "projects/:id/merge_requests?state=all&per_page=1" | jq length


### PR DESCRIPTION
## Summary

- Extracts atomic `.sh` command files from existing cluster `.md` files — one shell operation per file, matching filenames across platforms
- 25 GitHub + 25 GitLab command files under `skill-references/{github,gitlab}/commands/`
- Phase 1 of 4 for issue #83. Skills are refactored in phase 3 to consume these via `!`cat`` includes.

Relates to https://github.com/ahoym/dotfiles/issues/83

🤖 Generated with [Claude Code](https://claude.com/claude-code)