### PR TITLE
feat: add platform symlink to setup-claude.sh (#83 — phase 4)

### DIFF
--- a/setup-claude.sh
+++ b/setup-claude.sh
@@ -40,3 +40,42 @@ for item in "${ITEMS[@]}"; do
   ln -s "$src" "$dest"
   echo "  link   $item -> $src"
 done
+
+# --- Platform-specific commands symlink ---
+# Creates ~/.claude/platform-commands -> skill-references/{github,gitlab}/commands/
+# Skills use !`cat ~/.claude/platform-commands/<cmd>.sh` to inline platform commands.
+
+PLATFORM_FILE="$TARGET_DIR/.platform"
+PLATFORM_LINK="$TARGET_DIR/platform-commands"
+
+if [ -f "$PLATFORM_FILE" ]; then
+  PLATFORM=$(cat "$PLATFORM_FILE")
+  echo "  platform: $PLATFORM (cached in .platform)"
+else
+  printf "  Which platform does this machine use? [github/gitlab]: "
+  read -r PLATFORM
+  case "$PLATFORM" in
+    github|gitlab) ;;
+    *) echo "  error: expected github or gitlab, got $PLATFORM"; exit 1 ;;
+  esac
+  echo "$PLATFORM" > "$PLATFORM_FILE"
+  echo "  platform: $PLATFORM (saved to .platform)"
+fi
+
+PLATFORM_SRC="$DOTFILES_CLAUDE_DIR/skill-references/$PLATFORM/commands"
+
+if [ ! -d "$PLATFORM_SRC" ]; then
+  echo "  skip   platform-commands ($PLATFORM_SRC not found)"
+else
+  if [ -L "$PLATFORM_LINK" ] && [ "$(readlink "$PLATFORM_LINK")" = "$PLATFORM_SRC" ]; then
+    echo "  ok     platform-commands -> $PLATFORM/commands"
+  else
+    if [ -e "$PLATFORM_LINK" ] || [ -L "$PLATFORM_LINK" ]; then
+      backup="$PLATFORM_LINK.backup.$(date +%s)"
+      echo "  backup platform-commands -> $(basename $backup)"
+      mv "$PLATFORM_LINK" "$backup"
+    fi
+    ln -s "$PLATFORM_SRC" "$PLATFORM_LINK"
+    echo "  link   platform-commands -> $PLATFORM/commands"
+  fi
+fi

--- a/setup-claude.sh
+++ b/setup-claude.sh
@@ -50,6 +50,10 @@ PLATFORM_LINK="$TARGET_DIR/platform-commands"
 
 if [ -f "$PLATFORM_FILE" ]; then
   PLATFORM=$(cat "$PLATFORM_FILE")
+  case "$PLATFORM" in
+    github|gitlab) ;;
+    *) echo "  error: invalid cached platform '$PLATFORM'; delete .platform and re-run"; exit 1 ;;
+  esac
   echo "  platform: $PLATFORM (cached in .platform)"
 else
   printf "  Which platform does this machine use? [github/gitlab]: "
@@ -72,7 +76,7 @@ else
   else
     if [ -e "$PLATFORM_LINK" ] || [ -L "$PLATFORM_LINK" ]; then
       backup="$PLATFORM_LINK.backup.$(date +%s)"
-      echo "  backup platform-commands -> $(basename $backup)"
+      echo "  backup platform-commands -> $(basename "$backup")"
       mv "$PLATFORM_LINK" "$backup"
     fi
     ln -s "$PLATFORM_SRC" "$PLATFORM_LINK"


### PR DESCRIPTION
## Summary

- `setup-claude.sh` gains platform detection: prompts for `github`/`gitlab` on first run, caches in `~/.claude/.platform`
- Creates symlink: `~/.claude/platform-commands` -> `skill-references/{github,gitlab}/commands/`
- Skills use `!`cat ~/.claude/platform-commands/<cmd>.sh`` to inline the correct platform's commands at preprocessing time
- Idempotent: skips if symlink already correct, backs up if different

## Test plan

- [ ] Run `setup-claude.sh` — verify platform prompt appears and answer `github`
- [ ] Re-run — verify it reads from `.platform` cache (no prompt)
- [ ] `cat ~/.claude/platform-commands/create-review.sh` — verify symlink resolves

Relates to https://github.com/ahoym/dotfiles/issues/83

🤖 Generated with [Claude Code](https://claude.com/claude-code)