### PR TITLE
feat: add platform-command scripts for !-inline migration (#92)

### DIFF
--- a/claude/commands/extract-request-learnings/SKILL.md
+++ b/claude/commands/extract-request-learnings/SKILL.md
@@ -14,8 +14,6 @@ Systematically extract learnings from pull request (GitHub) or merge request (Gi
 
 ## Reference Files (conditional — read only when needed)
 
-- @~/.claude/skill-references/platform-detection.md
-- `~/.claude/skill-references/github/batch-operations.md` / `gitlab/batch-operations.md` — Batch metadata fetch, access verification, count
 - `extractor-prompt.md` — Read when spawning extractor subagents
 - `writer-prompt.md` — Read when spawning the writer subagent
 - `plan-template.md` — Read when initializing a new extraction plan
@@ -50,11 +48,11 @@ General/private writers use staging directories inside the project (`docs/learni
 
 ### Init mode (`init` arg)
 
-1. **Detect platform** — follow `@~/.claude/skill-references/platform-detection.md` to determine GitHub vs GitLab. Then read `~/.claude/skill-references/{github,gitlab}/batch-operations.md` (matching detected platform).
+1. **Verify platform access:**
+   !`cat ~/.claude/platform-commands/verify-platform-access.sh 2>/dev/null || echo "UNCONFIGURED: run setup-claude.sh to set up platform-commands"`
 
-2. **Verify platform access** — use **"Verify Platform Access (Batch)"** from the batch-operations cluster file, substituting `$API_CMD`.
-
-3. **Count total reviews** — use **"Count Total Reviews"** from the batch-operations cluster file, substituting `$API_CMD`.
+2. **Count total reviews:**
+   !`cat ~/.claude/platform-commands/count-total-reviews.sh 2>/dev/null || echo "UNCONFIGURED: run setup-claude.sh to set up platform-commands"`
 
 4. **Create plan file** at `docs/plans/$PLAN_FILENAME`:
    - Use the template in `plan-template.md`
@@ -75,7 +73,8 @@ General/private writers use staging directories inside the project (`docs/learni
 
 5. **Glob existing learnings files** in all output locations to build `EXISTING_CATEGORIES` for subagent prompts.
 
-6. **Fetch metadata** (1 bash call) — use **"Fetch Review Metadata (Batch)"** from the batch-operations cluster file, substituting `$API_CMD`, `BATCH_SIZE`, and `NEXT_PAGE`. Store result as `BATCH_METADATA`. Read `BATCH_SIZE` from the plan file (default: 10).
+6. **Fetch metadata** (1 bash call) — use the batch fetch command, substituting `BATCH_SIZE` and `NEXT_PAGE`. Store result as `BATCH_METADATA`. Read `BATCH_SIZE` from the plan file (default: 10).
+   !`cat ~/.claude/platform-commands/batch-fetch-reviews.sh 2>/dev/null || echo "UNCONFIGURED: run setup-claude.sh to set up platform-commands"`
 
 7. **Triage and spawn extractor subagents** in parallel. Read `extractor-prompt.md` and use it as a **verbatim template** — fill in placeholders but do not abbreviate, paraphrase, or add ad-hoc instructions. Every review gets the identical template structure. **Research only — no file writes.**
 

--- a/claude/commands/extract-request-learnings/extractor-prompt.md
+++ b/claude/commands/extract-request-learnings/extractor-prompt.md
@@ -23,7 +23,7 @@ Review metadata:
 
 ## Data fetching
 
-Read `~/.claude/skill-references/<PLATFORM>/comment-interaction.md` for comment commands and `~/.claude/skill-references/<PLATFORM>/fetch-review-data.md` for PR metadata commands (where `<PLATFORM>` is `github` or `gitlab`). Use these sections from those files:
+Read `~/.claude/platform-commands/` for platform-specific commands. Use these `.sh` files:
 
 **Step 1 (always run):**
 - **Fetch Inline/Review Comments** — use the full fetch variant

--- a/claude/commands/extract-request-learnings/extractor-prompt.md
+++ b/claude/commands/extract-request-learnings/extractor-prompt.md
@@ -23,7 +23,7 @@ Review metadata:
 
 ## Data fetching
 
-Use these scripts from `~/.claude/platform-commands/`:
+Use these scripts from `~/.claude/platform-commands/` (cat each and execute the result):
 
 **Step 1 (always run):**
 - `fetch-review-comments.sh` — use the full fetch variant

--- a/claude/commands/extract-request-learnings/extractor-prompt.md
+++ b/claude/commands/extract-request-learnings/extractor-prompt.md
@@ -23,17 +23,17 @@ Review metadata:
 
 ## Data fetching
 
-Read `~/.claude/platform-commands/` for platform-specific commands. Use these `.sh` files:
+Use these scripts from `~/.claude/platform-commands/`:
 
 **Step 1 (always run):**
-- **Fetch Inline/Review Comments** — use the full fetch variant
-- **Fetch Issue/Top-Level Comments**
+- `fetch-review-comments.sh` — use the full fetch variant
+- `fetch-issue-comments.sh`
 
 **Step 2 (always run):**
-- **Fetch Review Details**
+- `fetch-review-details.sh`
 
 **Step 3 (if discussion count > 10, OR state is closed, OR description signals substantial implementation — new module/adapter/integration/refactor):**
-- **Fetch Files Changed**
+- `fetch-review-files.sh`
 
 Do not fetch any other endpoints. These commands provide all the signal needed.
 

--- a/claude/commands/git/address-request-comments/SKILL.md
+++ b/claude/commands/git/address-request-comments/SKILL.md
@@ -23,7 +23,6 @@ Fetch and address review comments from a pull request (GitHub) or merge request 
 ## Reference Files (conditional — read only when needed)
 
 - `~/.claude/skill-references/request-interaction-base.md` — **Read first.** Shared fetch, tracking, footnote, and resolution patterns
-- Platform cluster files — loaded via the base reference's Platform Detection section
 - `request-reply-templates.md` — Read before composing replies (step 6)
 - `request-lgtm-verification.md` — Read only when an LGTM comment is detected
 - `address-request-edge-cases.md` — Read when processing comments (step 5+). Skip on quiet no-ops.
@@ -48,7 +47,7 @@ When `COMMENT_ONLY=true`:
 - **Adjust step 9** summary — action column uses "Commented (agree)", "Commented (disagree)", "Clarified", etc. instead of "Implemented" / "Awaiting your decision"
 - **Adjust step 13** summary — report comments posted, not changes implemented
 
-1. **Detect platform and fetch** — follow the base reference: **Platform Detection** → **Consolidated Fetch** → **Terminal State Handling**. Then fetch inline comments via **Fetch Inline/Review Comments** from the platform cluster files. Apply **Incremental Fetch Rules** and **Quiet No-Op** from the base reference. On quiet no-op, stop here.
+1. **Fetch request data** — follow the base reference: **Platform Commands** → **Consolidated Fetch** → **Terminal State Handling**. Then fetch inline comments via **Fetch Inline/Review Comments** from the platform command scripts. Apply **Incremental Fetch Rules** and **Quiet No-Op** from the base reference. On quiet no-op, stop here.
 
    **Never dismiss comments as duplicates based on topic.** Each comment ID is a distinct interaction that requires its own response — even if a previous comment on the same thread covered the same topic. A "duplicate" is only a comment you already replied to (same ID). Different comment IDs from different review passes are separate comments, not duplicates.
 

--- a/claude/commands/git/address-request-comments/SKILL.md
+++ b/claude/commands/git/address-request-comments/SKILL.md
@@ -30,7 +30,7 @@ Fetch and address review comments from a pull request (GitHub) or merge request 
 
 ## Instructions
 
-**Role:** Addresser. Read `~/.claude/skill-references/request-interaction-base.md` for shared patterns (platform detection, consolidated fetch, incremental tracking, footnotes, reply naming, mutual resolution). This skill uses `YOUR_ROLE=Addresser` and `OTHER_ROLE=Reviewer` throughout.
+**Role:** Addresser. Read `~/.claude/skill-references/request-interaction-base.md` for shared patterns (platform commands, consolidated fetch, incremental tracking, footnotes, reply naming, mutual resolution). This skill uses `YOUR_ROLE=Addresser` and `OTHER_ROLE=Reviewer` throughout.
 
 ### Mode Detection
 
@@ -56,7 +56,7 @@ When `COMMENT_ONLY=true`:
    - Show each comment with: file, line number, author, and content
    - Number each comment for reference (store as `COMMENTS` list)
 
-3. **Checkout the review branch** if not already on it — follow **Checkout Review Branch** in the platform cluster files. **Skip if `COMMENT_ONLY`.**
+3. **Checkout the review branch** if not already on it — follow **Checkout Review Branch** in the platform command scripts. **Skip if `COMMENT_ONLY`.**
 
 4. **Load relevant learnings**: Read `~/.claude/learnings-providers.json` to discover all provider directories. Glob each provider's `localPath/` and `docs/learnings/` filenames and identify any whose domain matches the comments' subject matter (e.g., a comment about skill structure → `claude-authoring-skills.md`, a comment about test patterns → `testing-*.md`). Read matched files so categorization and replies are grounded in established knowledge. Skip this for trivial comments (typos, praise).
 
@@ -82,11 +82,11 @@ When `COMMENT_ONLY=true`:
    - For suggestions: Enumerate the reviewer's distinct points. Map your proposed change to each one. If your plan doesn't cover a point, address it or push back on why. Push back on points you disagree with rather than silently skipping them.
    - For clarification requests: Provide the explanation
    - For typo/bug fixes: Acknowledge and confirm you'll fix it (or "recommend fixing" if `COMMENT_ONLY`)
-   - For general feedback/positive signals: React with a `rocket` emoji only. Follow **React to Comment** in the platform cluster files. No text reply needed.
+   - For general feedback/positive signals: React with a `rocket` emoji only. Follow **React to Comment** in the platform command scripts. No text reply needed.
 
    **IMPORTANT:** Do NOT prompt the operator in CLI for approval at this step. Always reply to comments on the platform first.
 
-   Append the **Footnote Format** from the base reference to every reply. Follow **Reply to Inline Comment** in the platform cluster files. Use **Reply File Naming** convention from the base reference.
+   Append the **Footnote Format** from the base reference to every reply. Follow **Reply to Inline Comment** in the platform command scripts. Use **Reply File Naming** convention from the base reference.
 
 8. **Act on suggestions based on agreement** — **Skip if `COMMENT_ONLY`.**
 
@@ -125,7 +125,7 @@ When `COMMENT_ONLY=true`:
    | 2 | auth.py:48 | Restructure auth flow | Commented (disagree) — pushed back |
    ```
 
-   Follow **Post Top-Level Comment** in the platform cluster files.
+   Follow **Post Top-Level Comment** in the platform command scripts.
 
 10. **Implement changes** — **Skip if `COMMENT_ONLY`.**
     a. Group changes by logical concern (e.g., variable elimination, section reordering, typo fixes). Each group becomes its own commit.
@@ -152,7 +152,7 @@ When `COMMENT_ONLY=true`:
 
     **Do not skip this step.** Step 7 posted an initial reply (acknowledgement/agreement). This step posts a **second reply** on the same threads with the commit hash. Reviewers need the commit ref to verify the fix — the review actions summary alone is not enough.
 
-    For each implemented suggestion/fix, follow **Reply to Inline Comment** in the platform cluster files. Include `Fixed in <COMMIT_HASH>` in the body, referencing the specific commit that addressed that comment.
+    For each implemented suggestion/fix, follow **Reply to Inline Comment** in the platform command scripts. Include `Fixed in <COMMIT_HASH>` in the body, referencing the specific commit that addressed that comment.
 
     For suggestions that were skipped (not approved):
     - Do not reply automatically

--- a/claude/commands/git/code-review-request/SKILL.md
+++ b/claude/commands/git/code-review-request/SKILL.md
@@ -37,7 +37,6 @@ For prompt-free execution, ensure these allow patterns in `~/.claude/settings.lo
 ## Reference Files (conditional — read only when needed)
 
 - `~/.claude/skill-references/request-interaction-base.md` — **Read first.** Shared fetch, tracking, footnote, and resolution patterns
-- Platform cluster files — loaded via the base reference's Platform Detection section
 - `re-review-mode.md` — Read only when `MODE=re-review` (step 4)
 
 ## Instructions
@@ -46,7 +45,7 @@ For prompt-free execution, ensure these allow patterns in `~/.claude/settings.lo
 
 1. **Verify active persona** — a persona is active if set via `/set-persona` or an ad-hoc prompt (e.g., "act as a senior infosec engineer", "you are a security reviewer"). For ad-hoc, extract a short name and proceed. If neither is active, glob `.claude/personas/` and `~/.claude/commands/set-persona/` for available personas, recommend the best match, and wait for activation. The persona shapes every aspect of the review — proceeding without one produces generic feedback.
 
-2. **Detect platform** — follow **Platform Detection** from the base reference.
+2. **Platform commands** — platform-specific commands are inlined via `!` preprocessing. No detection needed.
 
 3. **Resolve the request and detect mode** — resolve the request number from `$ARGUMENTS` (URL → extract number, number → use directly, empty → detect from current branch). Then follow the base reference: **Consolidated Fetch** → **Terminal State Handling**.
 

--- a/claude/commands/git/code-review-request/SKILL.md
+++ b/claude/commands/git/code-review-request/SKILL.md
@@ -41,7 +41,7 @@ For prompt-free execution, ensure these allow patterns in `~/.claude/settings.lo
 
 ## Instructions
 
-**Role:** Reviewer. Read `~/.claude/skill-references/request-interaction-base.md` for shared patterns (platform detection, consolidated fetch, incremental tracking, footnotes, reply naming, mutual resolution, comment identity). This skill uses `YOUR_ROLE=Reviewer` and `OTHER_ROLE=Addresser` throughout.
+**Role:** Reviewer. Read `~/.claude/skill-references/request-interaction-base.md` for shared patterns (platform commands, consolidated fetch, incremental tracking, footnotes, reply naming, mutual resolution, comment identity). This skill uses `YOUR_ROLE=Reviewer` and `OTHER_ROLE=Addresser` throughout.
 
 1. **Verify active persona** — a persona is active if set via `/set-persona` or an ad-hoc prompt (e.g., "act as a senior infosec engineer", "you are a security reviewer"). For ad-hoc, extract a short name and proceed. If neither is active, glob `.claude/personas/` and `~/.claude/commands/set-persona/` for available personas, recommend the best match, and wait for activation. The persona shapes every aspect of the review — proceeding without one produces generic feedback.
 
@@ -63,7 +63,7 @@ For prompt-free execution, ensure these allow patterns in `~/.claude/settings.lo
 
    **Re-review mode** — two-phase check, short-circuiting on the first signal:
 
-   **Phase 1 (1 call):** Use **"Fetch Activity Signals (consolidated)"** from the platform cluster files. Parse the JSON response to check:
+   **Phase 1 (1 call):** Use **"Fetch Activity Signals (consolidated)"** from the platform command scripts. Parse the JSON response to check:
    - **New commits**: latest commit SHA differs from last reviewed
    - **New reviews from others**: any review with a non-empty body submitted after `LAST_REVIEW_TS` that doesn't contain our persona+role footnote. Ignore empty-body reviews — they're wrappers for inline comments, which phase 2 catches reliably.
    - **New top-level comments**: any comment created after `LAST_REVIEW_TS`
@@ -71,7 +71,7 @@ For prompt-free execution, ensure these allow patterns in `~/.claude/settings.lo
 
    If any activity signal → proceed to step 6+ (skip phase 2).
 
-   **Phase 2 (1 call, only if phase 1 found nothing):** Use **"Fetch Recent Inline Comments (quick-exit check)"** from the platform cluster files (fetches 10). Filter out self-comments (`Role:.*<YOUR_ROLE>` in body). Non-self present and some new → proceed. Non-self present and all old → skip. All self → inconclusive, fall through to full incremental fetch.
+   **Phase 2 (1 call, only if phase 1 found nothing):** Use **"Fetch Recent Inline Comments (quick-exit check)"** from the platform command scripts (fetches 10). Filter out self-comments (`Role:.*<YOUR_ROLE>` in body). Non-self present and some new → proceed. Non-self present and all old → skip. All self → inconclusive, fall through to full incremental fetch.
 
    This is 1 call when there's new activity in phase 1, 2 calls when polling quietly. All four activity signals (commits, non-empty reviews, top-level comments, inline comments) are covered.
 
@@ -82,7 +82,7 @@ For prompt-free execution, ensure these allow patterns in `~/.claude/settings.lo
    PR #<REQUEST_NUMBER>: no changes since last review (<LAST_REVIEW_TS>). Skipping. 🔄
    ```
 
-6. **Fetch PR metadata and diff** — run these in parallel using the platform cluster files:
+6. **Fetch PR metadata and diff** — run these in parallel using the platform command scripts:
 
    - **Fetch Diff** — use the **"Fetch Diff"** section
    - **Fetch Files Changed** — use the **"Fetch Files Changed"** section
@@ -147,7 +147,7 @@ For prompt-free execution, ensure these allow patterns in `~/.claude/settings.lo
 
    **Each inline comment and follow-up reply** must also end with the footnote.
 
-11. **Post the review** — use the **"Post Review with Inline Comments"** section from the platform cluster files. Write the review payload following the **Reply File Naming** convention from the base reference (e.g., `tmp/claude-artifacts/change-request-replies/review-<REQUEST_NUMBER>-<PERSONA>-reviewer.json`).
+11. **Post the review** — use the **"Post Review with Inline Comments"** section from the platform command scripts. Write the review payload following the **Reply File Naming** convention from the base reference (e.g., `tmp/claude-artifacts/change-request-replies/review-<REQUEST_NUMBER>-<PERSONA>-reviewer.json`).
 
     **Re-review only:** Also execute reactions and follow-ups per `re-review-mode.md`.
 

--- a/claude/commands/git/create-request/SKILL.md
+++ b/claude/commands/git/create-request/SKILL.md
@@ -18,8 +18,6 @@ Create a pull request (GitHub) or merge request (GitLab), or update an existing 
 
 ## Reference Files (conditional — read only when needed)
 
-- `~/.claude/skill-references/platform-detection.md` — read if platform not yet detected this session
-- `~/.claude/skill-references/github/pr-management.md` / `gitlab/pr-management.md` — Create/update PR, check existing
 - `request-body-template.md` — Read before composing review body (step 9). Located in the skill's base directory.
 
 ## Pre-Review Checklist
@@ -35,7 +33,7 @@ Before creating the review, verify these items are complete:
 
 ## Instructions
 
-1. **Detect platform** — if not already detected this session, read `~/.claude/skill-references/platform-detection.md` and follow its logic to determine GitHub vs GitLab. Then read `~/.claude/skill-references/{github,gitlab}/pr-management.md` (matching detected platform).
+1. **Gather platform commands** — platform-specific commands are inlined below via `!` preprocessing. No detection or file loading needed.
 
 2. **Gather context** (run in parallel):
    - `git status` - Check for uncommitted changes
@@ -61,9 +59,9 @@ Before creating the review, verify these items are complete:
 
    Skip checks that aren't configured for the project. Don't install new tools.
 
-5. **Check for existing review** — follow **"Check for Existing Review"** in the platform cluster files.
-   - If a review already exists, ask the operator: "$REVIEW_UNIT #N already exists for this branch. Update its description instead of creating new?"
-   - If yes, use `$EDIT_CMD` instead of `$CREATE_CMD`
+5. **Check for existing review:**
+   !`cat ~/.claude/platform-commands/check-existing-review.sh 2>/dev/null || echo "UNCONFIGURED: run setup-claude.sh to set up platform-commands"`
+   - If a review already exists, ask the operator: "Review #N already exists for this branch. Update its description instead of creating new?"
 
 6. **Determine base branch**:
    - If `$ARGUMENTS` provided, use that as base
@@ -80,7 +78,11 @@ Before creating the review, verify these items are complete:
 
 9. **Compose review body** — Read `request-body-template.md` from the skill's base directory. Structure the body following that template.
 
-10. **Write body and create/update review** — Using the pr-management cluster file loaded in step 1, follow the **"Create or Update PR (Body via File)"** section. Use `<BRANCH_NAME>` in the temp filename for parallel safety.
+10. **Write body and create/update review** — Use `<BRANCH_NAME>` in the temp filename for parallel safety.
+    **Create:**
+    !`cat ~/.claude/platform-commands/create-review.sh 2>/dev/null || echo "UNCONFIGURED: run setup-claude.sh to set up platform-commands"`
+    **Update (if existing review):**
+    !`cat ~/.claude/platform-commands/update-review.sh 2>/dev/null || echo "UNCONFIGURED: run setup-claude.sh to set up platform-commands"`
 
 11. **Clean up** — remove the temp body file and empty `tmp/claude-artifacts/change-request-replies/` directory (per the platform commands section).
 

--- a/claude/commands/git/explore-request/SKILL.md
+++ b/claude/commands/git/explore-request/SKILL.md
@@ -37,9 +37,9 @@ Pull down a review to understand its changes, get context, and ask questions.
    - **Fetch Commits:**
      !`cat ~/.claude/platform-commands/fetch-review-commits.sh 2>/dev/null || echo "UNCONFIGURED: run setup-claude.sh to set up platform-commands"`
 
-4. **Display review summary** (store as `REVIEW_CONTEXT`):
+3. **Display review summary** (store as `REVIEW_CONTEXT`):
    ```
-   $REVIEW_UNIT $REVIEW_PREFIX<number>: <title>
+   PR #<number>: <title>
    Author: <author>
    Branch: <source_branch> → <target_branch>
    Status: <state>
@@ -59,27 +59,23 @@ Pull down a review to understand its changes, get context, and ask questions.
    ...
    ```
 
-5. **Fetch the diff** (store as `REVIEW_DIFF`):
-   ```bash
-   $DIFF_CMD <number>
-   ```
+4. **Fetch the diff** (store as `REVIEW_DIFF`):
+   !`cat ~/.claude/platform-commands/fetch-review-diff.sh 2>/dev/null || echo "UNCONFIGURED: run setup-claude.sh to set up platform-commands"`
    If diff is large (>500 lines), summarize by file:
    - Show first 50 lines of each file's diff
    - Note "... and X more lines" for truncated sections
 
-6. **Offer to checkout** the review branch (optional):
+5. **Offer to checkout** the review branch (optional):
    Ask: "Would you like me to checkout this branch locally? (y/n)"
 
    If yes:
-   ```bash
-   $CHECKOUT_CMD <number>
-   ```
+   !`cat ~/.claude/platform-commands/checkout-review.sh 2>/dev/null || echo "UNCONFIGURED: run setup-claude.sh to set up platform-commands"`
 
-7. **Enter Q&A mode**:
+6. **Enter Q&A mode**:
    Present to the operator:
    ```
-   I now have full context on $REVIEW_UNIT $REVIEW_PREFIX<number>. You can ask me:
-   - What does this $REVIEW_UNIT change?
+   I now have full context on PR #<number>. You can ask me:
+   - What does this PR change?
    - Why was <file> modified?
    - Are there any potential issues?
    - How does <function/class> work now?
@@ -88,7 +84,7 @@ Pull down a review to understand its changes, get context, and ask questions.
    Ask any questions about this review, or say "done" to exit.
    ```
 
-8. **Answer questions** using `REVIEW_CONTEXT` and `REVIEW_DIFF`:
+7. **Answer questions** using `REVIEW_CONTEXT` and `REVIEW_DIFF`:
    - Reference specific files and line numbers when answering
    - Read additional files if needed for context
    - If a question requires understanding code not in the diff, use Read tool

--- a/claude/commands/git/explore-request/SKILL.md
+++ b/claude/commands/git/explore-request/SKILL.md
@@ -22,26 +22,20 @@ Pull down a review to understand its changes, get context, and ask questions.
 - `/git:explore-request <url>` - Explore review by URL
 - `/git:explore-request` - Explore review for current branch (if one exists)
 
-## Reference Files (conditional — read only when needed)
-
-- `~/.claude/skill-references/platform-detection.md` — read if platform not yet detected this session
-- `~/.claude/skill-references/github/fetch-review-data.md` / `gitlab/fetch-review-data.md` — Fetch PR/MR details, diff, files, commits
-
 ## Instructions
 
-1. **Detect platform** — if not already detected this session, read `~/.claude/skill-references/platform-detection.md` and follow its logic to determine GitHub vs GitLab. Then read `~/.claude/skill-references/{github,gitlab}/fetch-review-data.md` (matching detected platform).
-
-2. **Parse review identifier** from `$ARGUMENTS`:
+1. **Parse review identifier** from `$ARGUMENTS`:
    - If empty, use current branch's review
    - If numeric, treat as review number
    - If URL (contains `URL_PATTERN`), extract review number from URL
 
-3. **Fetch review metadata** (run in parallel):
-
-   Using the fetch-review-data cluster file loaded in step 1, follow:
-   - **Fetch Review Details** — get number, title, body, author, branches, state, timestamps
-   - **Fetch Files Changed** — get list of modified file paths
-   - **Fetch Commits** — get short SHAs and commit messages
+2. **Fetch review metadata** (run in parallel):
+   - **Fetch Review Details:**
+     !`cat ~/.claude/platform-commands/fetch-review-details.sh 2>/dev/null || echo "UNCONFIGURED: run setup-claude.sh to set up platform-commands"`
+   - **Fetch Files Changed:**
+     !`cat ~/.claude/platform-commands/fetch-review-files.sh 2>/dev/null || echo "UNCONFIGURED: run setup-claude.sh to set up platform-commands"`
+   - **Fetch Commits:**
+     !`cat ~/.claude/platform-commands/fetch-review-commits.sh 2>/dev/null || echo "UNCONFIGURED: run setup-claude.sh to set up platform-commands"`
 
 4. **Display review summary** (store as `REVIEW_CONTEXT`):
    ```

--- a/claude/commands/git/repoint-branch/SKILL.md
+++ b/claude/commands/git/repoint-branch/SKILL.md
@@ -39,7 +39,7 @@ Extract independent changes from a compound branch into a new branch targeting m
 
 ## Instructions
 
-0. **Platform commands** — platform-specific commands are inlined below via `!` preprocessing. No detection needed.
+0. **Platform commands** — commands below are GitHub-specific (`gh`). No platform detection needed.
 
 1. **Parse arguments**:
    - Extract `--name <branch-name>` if provided

--- a/claude/commands/git/repoint-branch/SKILL.md
+++ b/claude/commands/git/repoint-branch/SKILL.md
@@ -39,7 +39,7 @@ Extract independent changes from a compound branch into a new branch targeting m
 
 ## Instructions
 
-0. **Platform commands** — commands below are GitHub-specific (`gh`). No platform detection needed.
+0. **Platform commands** — all commands below are plain `git`. PR creation delegates to `/git:create-request` (handles both GitHub and GitLab).
 
 1. **Parse arguments**:
    - Extract `--name <branch-name>` if provided
@@ -98,10 +98,7 @@ Extract independent changes from a compound branch into a new branch targeting m
    git push -u origin <new-branch-name>
    ```
    Ask: "Create a PR to main? (y/n)"
-   If yes, run `/git:create-request` or:
-   ```bash
-   gh pr create --base main --title "<title>" --body "..."
-   ```
+   If yes, run `/git:create-request`.
 
 9. **Return to original branch**:
    ```bash

--- a/claude/commands/git/repoint-branch/SKILL.md
+++ b/claude/commands/git/repoint-branch/SKILL.md
@@ -37,13 +37,9 @@ Extract independent changes from a compound branch into a new branch targeting m
 /repoint-branch .claude/guidelines/ .claude/commands/ --name feature/claude-config-lite
 ```
 
-## Reference Files (conditional — read only when needed)
-
-- `~/.claude/skill-references/platform-detection.md` — read if platform not yet detected this session
-
 ## Instructions
 
-0. **Detect platform** — if not already detected this session, read `~/.claude/skill-references/platform-detection.md` and follow its logic to determine GitHub vs GitLab. Set `CLI`, `REVIEW_UNIT`, and API command patterns accordingly. All commands below use GitHub (`gh`) syntax; substitute GitLab equivalents if on GitLab.
+0. **Platform commands** — platform-specific commands are inlined below via `!` preprocessing. No detection needed.
 
 1. **Parse arguments**:
    - Extract `--name <branch-name>` if provided

--- a/claude/commands/git/resolve-conflicts/SKILL.md
+++ b/claude/commands/git/resolve-conflicts/SKILL.md
@@ -21,13 +21,9 @@ Resolve merge or rebase conflicts between your PR branch and its base branch.
 
 Flags can be combined: `/resolve-conflicts --merge main`
 
-## Reference Files (conditional — read only when needed)
-
-- `~/.claude/skill-references/platform-detection.md` — read if platform not yet detected this session
-
 ## Instructions
 
-0. **Detect platform** — if not already detected this session, read `~/.claude/skill-references/platform-detection.md` and follow its logic to determine GitHub vs GitLab. Set `CLI`, `REVIEW_UNIT`, and API command patterns accordingly. All commands below use GitHub (`gh`) syntax; substitute GitLab equivalents if on GitLab.
+0. **Platform commands** — platform-specific commands are inlined below via `!` preprocessing. No detection needed.
 
 1. **Parse arguments**:
    - If `$ARGUMENTS` contains `--preview`, set `PREVIEW_ONLY=true`

--- a/claude/commands/git/split-request/SKILL.md
+++ b/claude/commands/git/split-request/SKILL.md
@@ -20,19 +20,12 @@ Analyze a large review and propose how to split it into smaller, reviewable unit
 - `/git:split-request <number>` - Analyze review and propose split strategy
 - `/git:split-request` - Analyze current branch's review
 
-## Reference Files (conditional — read only when needed)
-
-- `~/.claude/skill-references/platform-detection.md` — read if platform not yet detected this session
-- `~/.claude/skill-references/github/fetch-review-data.md` / `gitlab/fetch-review-data.md` — Fetch PR/MR details
-
 ## Instructions
 
-1. **Detect platform** — if not already detected this session, read `~/.claude/skill-references/platform-detection.md` and follow its logic to determine GitHub vs GitLab. Then read `~/.claude/skill-references/{github,gitlab}/fetch-review-data.md` (matching detected platform).
-
-2. **Fetch review details**:
+1. **Fetch review details:**
+   !`cat ~/.claude/platform-commands/fetch-review-details.sh 2>/dev/null || echo "UNCONFIGURED: run setup-claude.sh to set up platform-commands"`
+   !`cat ~/.claude/platform-commands/checkout-review.sh 2>/dev/null || echo "UNCONFIGURED: run setup-claude.sh to set up platform-commands"`
    ```bash
-   $VIEW_CMD <number> $VIEW_JSON_FLAGS
-   $CHECKOUT_CMD <number>
    git log main..HEAD --oneline
    git diff main --stat
    ```

--- a/claude/commands/git/team-review-request/SKILL.md
+++ b/claude/commands/git/team-review-request/SKILL.md
@@ -38,7 +38,6 @@ For prompt-free execution, ensure these allow patterns in `~/.claude/settings.lo
 ## Reference Files (conditional — read only when needed)
 
 - `~/.claude/skill-references/request-interaction-base.md` — **Read first.** Shared fetch, tracking, footnote, and resolution patterns
-- Platform cluster files — loaded via the base reference's Platform Detection section
 - `persona-routing.md` — Read at step 5 for persona selection and step 10 for merge algorithm
 - `reviewer-prompt-template.md` — Read at step 8, injected into subagent prompts
 - `single-reviewer-mode.md` — Read only when N=1 (step 5 selects one persona)

--- a/claude/commands/git/team-review-request/SKILL.md
+++ b/claude/commands/git/team-review-request/SKILL.md
@@ -50,7 +50,7 @@ For prompt-free execution, ensure these allow patterns in `~/.claude/settings.lo
 
 **Orchestrator personas:** Read `~/.claude/commands/set-persona/team-lead.md` and `~/.claude/commands/set-persona/reviewer.md` at skill start. The `team-lead` persona guides merge, overview composition, and deliberation. The `reviewer` persona provides base review instincts. These are the orchestrator's own lenses — distinct from the domain reviewer personas selected for subagents in step 5.
 
-1. **Detect platform** — follow **Platform Detection** from the base reference. If not already detected this session, read `~/.claude/skill-references/platform-detection.md` and set `CLI`, `REVIEW_UNIT`, and API command patterns. Then read the matching platform cluster files.
+1. **Platform commands** — platform-specific commands are inlined via `!` preprocessing. No detection needed.
 
 2. **Resolve the request and detect mode** — resolve the request number from `$ARGUMENTS` (URL → extract number, number → use directly, empty → detect from current branch). Then follow the base reference: **Consolidated Fetch** → **Terminal State Handling**.
 

--- a/claude/commands/sweep/address-prs/SKILL.md
+++ b/claude/commands/sweep/address-prs/SKILL.md
@@ -84,7 +84,7 @@ Read `~/.claude/settings.json`, check every required pattern is present (exact s
 
 ### Phase 2: PR Fetch
 
-Fetch open PRs (platform commands are inlined via `!` preprocessing):
+Fetch open PRs (GitHub-specific commands):
 - Specific numbers: `gh pr view <N> --json number,title,headRefName,baseRefName,url,state,isDraft,mergeable,reviews,comments`
 - All open: `gh pr list --state open --json number,title,headRefName,baseRefName,url,isDraft,mergeable --limit <MAX_PRS>`, then fetch `reviews,comments` per PR separately
 

--- a/claude/commands/sweep/address-prs/SKILL.md
+++ b/claude/commands/sweep/address-prs/SKILL.md
@@ -64,8 +64,6 @@ If missing, report with `BLOCKED:` prefix listing each missing pattern. Do not c
 
 ## Reference Files
 
-- @~/.claude/skill-references/platform-detection.md — GitHub vs GitLab detection
-- `~/.claude/skill-references/{github,gitlab}/pr-management.md` — PR fetch commands
 - `~/.claude/skill-references/parallel-claude-runner-template.sh` — Bash template for let-it-rip.sh generation
 - `~/.claude/skill-references/fill-template.sh` — Bash assembly for prompt generation (replaces LLM string substitution)
 - @~/.claude/skill-references/sweep-scaffold.md — Shared artifact structure, watermark logic, result/learnings patterns, announce/progress/retro formats
@@ -84,9 +82,9 @@ Read `~/.claude/settings.json`, check every required pattern is present (exact s
 - **`--concurrency=<N>`** → `CONCURRENCY` (default 3)
 - **`--resolve-conflicts`** → `RESOLVE_CONFLICTS` (default false) — resolve merge conflicts with base branch before addressing comments
 
-### Phase 2: Platform Detection & PR Fetch
+### Phase 2: PR Fetch
 
-Follow `platform-detection.md`. Then fetch open PRs:
+Fetch open PRs (platform commands are inlined via `!` preprocessing):
 - Specific numbers: `gh pr view <N> --json number,title,headRefName,baseRefName,url,state,isDraft,mergeable,reviews,comments`
 - All open: `gh pr list --state open --json number,title,headRefName,baseRefName,url,isDraft,mergeable --limit <MAX_PRS>`, then fetch `reviews,comments` per PR separately
 

--- a/claude/commands/sweep/review-prs/SKILL.md
+++ b/claude/commands/sweep/review-prs/SKILL.md
@@ -81,7 +81,7 @@ Read `~/.claude/settings.json`, check every required pattern is present (exact s
 
 ### Phase 2: PR Fetch
 
-Fetch open PRs (platform commands are inlined via `!` preprocessing):
+Fetch open PRs (GitHub-specific commands):
 - Specific numbers: `gh pr view <N> --json number,title,headRefName,baseRefName,url,state,isDraft,reviews,comments`
 - All open: `gh pr list --state open --json number,title,headRefName,baseRefName,url,isDraft --limit <MAX_PRS>`, then fetch `reviews,comments` per PR separately
 

--- a/claude/commands/sweep/review-prs/SKILL.md
+++ b/claude/commands/sweep/review-prs/SKILL.md
@@ -61,8 +61,6 @@ If missing, report with `BLOCKED:` prefix listing each missing pattern. Do not c
 
 ## Reference Files
 
-- @~/.claude/skill-references/platform-detection.md — GitHub vs GitLab detection
-- `~/.claude/skill-references/{github,gitlab}/pr-management.md` — PR fetch commands
 - `~/.claude/skill-references/parallel-claude-runner-template.sh` — Bash template for let-it-rip.sh generation
 - `~/.claude/skill-references/fill-template.sh` — Bash assembly for prompt generation (replaces LLM string substitution)
 - @~/.claude/skill-references/sweep-scaffold.md — Shared artifact structure, watermark logic, result/learnings patterns, announce/progress/retro formats
@@ -81,9 +79,9 @@ Read `~/.claude/settings.json`, check every required pattern is present (exact s
 - **`--concurrency=<N>`** → `CONCURRENCY` (default 3)
 - **`--include-drafts`** → `INCLUDE_DRAFTS` (default false)
 
-### Phase 2: Platform Detection & PR Fetch
+### Phase 2: PR Fetch
 
-Follow `platform-detection.md`. Then fetch open PRs:
+Fetch open PRs (platform commands are inlined via `!` preprocessing):
 - Specific numbers: `gh pr view <N> --json number,title,headRefName,baseRefName,url,state,isDraft,reviews,comments`
 - All open: `gh pr list --state open --json number,title,headRefName,baseRefName,url,isDraft --limit <MAX_PRS>`, then fetch `reviews,comments` per PR separately
 

--- a/claude/commands/sweep/work-items/SKILL.md
+++ b/claude/commands/sweep/work-items/SKILL.md
@@ -92,7 +92,7 @@ Parse `$ARGUMENTS` to extract:
 
 ### Phase 2: Issue Fetch
 
-1. Fetch work items (platform commands are inlined via `!` preprocessing):
+1. Fetch work items (GitHub-specific commands):
    - Specific numbers: `gh issue view <N> --json number,title,body,labels,assignees,comments,url,updatedAt`
    - Label filter: `gh issue list --state open --label <LABEL> --json number,title,body,labels,assignees,updatedAt --limit <MAX>`
    - No filters: `gh issue list --state open --json number,title,body,labels,assignees,updatedAt --limit <MAX>`

--- a/claude/commands/sweep/work-items/SKILL.md
+++ b/claude/commands/sweep/work-items/SKILL.md
@@ -68,9 +68,6 @@ If missing, report with `BLOCKED:` prefix listing each missing pattern. Do not c
 
 ## Reference Files
 
-- @~/.claude/skill-references/platform-detection.md — GitHub vs GitLab detection
-- `~/.claude/skill-references/{github,gitlab}/issue-operations.md` — Issue fetch, comment commands
-- `~/.claude/skill-references/{github,gitlab}/pr-management.md` — PR creation (for implementer context)
 - `~/.claude/skill-references/parallel-claude-runner-template.sh` — Bash template for let-it-rip.sh generation
 - `~/.claude/skill-references/fill-template.sh` — Bash assembly for prompt generation (replaces LLM string substitution)
 - @~/.claude/skill-references/sweep-scaffold.md — Shared artifact structure, watermark logic, result/learnings patterns
@@ -93,11 +90,9 @@ Parse `$ARGUMENTS` to extract:
 - **Max**: `--max=<N>` → `MAX_ISSUES` (default 30)
 - **Concurrency**: `--concurrency=<N>` → `CONCURRENCY` (default 5)
 
-### Phase 2: Platform Detection & Issue Fetch
+### Phase 2: Issue Fetch
 
-1. Follow `platform-detection.md` to determine GitHub vs GitLab. Read the matching `issue-operations.md` cluster.
-
-2. Fetch work items:
+1. Fetch work items (platform commands are inlined via `!` preprocessing):
    - Specific numbers: `gh issue view <N> --json number,title,body,labels,assignees,comments,url,updatedAt`
    - Label filter: `gh issue list --state open --label <LABEL> --json number,title,body,labels,assignees,updatedAt --limit <MAX>`
    - No filters: `gh issue list --state open --json number,title,body,labels,assignees,updatedAt --limit <MAX>`

--- a/claude/skill-references/github/commands/check-issue-state.sh
+++ b/claude/skill-references/github/commands/check-issue-state.sh
@@ -1,0 +1,1 @@
+gh issue view <N> --json state -q '.state'

--- a/claude/skill-references/github/commands/check-pr-mergeable.sh
+++ b/claude/skill-references/github/commands/check-pr-mergeable.sh
@@ -1,0 +1,1 @@
+gh pr view <N> --json mergeable --jq '.mergeable'

--- a/claude/skill-references/github/commands/fetch-issue-with-comments.sh
+++ b/claude/skill-references/github/commands/fetch-issue-with-comments.sh
@@ -1,0 +1,2 @@
+# Fetch issue metadata with latest comment info
+gh issue view <N> --json updatedAt,comments --jq '{updatedAt, last_comment_id: (.comments[-1].id // null), last_comment_body: (.comments[-1].body // null)}'

--- a/claude/skill-references/github/commands/fetch-pr-base-branch.sh
+++ b/claude/skill-references/github/commands/fetch-pr-base-branch.sh
@@ -1,0 +1,1 @@
+gh pr view <N> --json baseRefName --jq '.baseRefName'

--- a/claude/skill-references/github/commands/list-open-prs.sh
+++ b/claude/skill-references/github/commands/list-open-prs.sh
@@ -1,0 +1,1 @@
+gh pr list --state open --json headRefName,number,url

--- a/claude/skill-references/github/commands/list-prs-by-branch.sh
+++ b/claude/skill-references/github/commands/list-prs-by-branch.sh
@@ -1,0 +1,1 @@
+gh pr list --state all --search "head:<BRANCH>" --json number,headRefName,state

--- a/claude/skill-references/github/commands/list-prs-by-issue-ref.sh
+++ b/claude/skill-references/github/commands/list-prs-by-issue-ref.sh
@@ -1,0 +1,1 @@
+gh pr list --state all --search "#<N>" --json number,headRefName,state,body

--- a/claude/skill-references/github/commands/post-code-review.sh
+++ b/claude/skill-references/github/commands/post-code-review.sh
@@ -1,0 +1,2 @@
+# Write review JSON via Write tool, then:
+gh api repos/{owner}/{repo}/pulls/<N>/reviews --input <FILE>

--- a/claude/skill-references/gitlab/commands/check-issue-state.sh
+++ b/claude/skill-references/gitlab/commands/check-issue-state.sh
@@ -1,0 +1,2 @@
+# GitLab issue state (v2 stub)
+glab api projects/:id/issues/<IID> --jq '.state'

--- a/claude/skill-references/gitlab/commands/check-pr-mergeable.sh
+++ b/claude/skill-references/gitlab/commands/check-pr-mergeable.sh
@@ -1,0 +1,2 @@
+# GitLab MR mergeable check (v2 stub)
+glab api projects/:id/merge_requests/<IID> --jq '.merge_status'

--- a/claude/skill-references/gitlab/commands/fetch-issue-with-comments.sh
+++ b/claude/skill-references/gitlab/commands/fetch-issue-with-comments.sh
@@ -1,0 +1,5 @@
+# GitLab issue with latest note (v2 stub)
+# Requires two calls — issue metadata + notes
+glab api projects/:id/issues/<IID> --jq '{updated_at}'
+# Latest note:
+glab api projects/:id/issues/<IID>/notes -F sort=desc -F per_page=1 --jq '.[0] | {id, body}'

--- a/claude/skill-references/gitlab/commands/fetch-pr-base-branch.sh
+++ b/claude/skill-references/gitlab/commands/fetch-pr-base-branch.sh
@@ -1,0 +1,2 @@
+# GitLab MR target branch (v2 stub)
+glab api projects/:id/merge_requests/<IID> --jq '.target_branch'

--- a/claude/skill-references/gitlab/commands/list-open-prs.sh
+++ b/claude/skill-references/gitlab/commands/list-open-prs.sh
@@ -1,0 +1,2 @@
+# GitLab open MRs (v2 stub)
+glab api projects/:id/merge_requests -F state=opened --jq '.[] | {iid, source_branch, web_url}'

--- a/claude/skill-references/gitlab/commands/list-prs-by-branch.sh
+++ b/claude/skill-references/gitlab/commands/list-prs-by-branch.sh
@@ -1,0 +1,2 @@
+# GitLab MRs by source branch (v2 stub)
+glab api projects/:id/merge_requests -F source_branch=<BRANCH> -F state=all --jq '.[] | {iid, source_branch, state}'

--- a/claude/skill-references/gitlab/commands/list-prs-by-issue-ref.sh
+++ b/claude/skill-references/gitlab/commands/list-prs-by-issue-ref.sh
@@ -1,0 +1,3 @@
+# GitLab MRs referencing an issue (v2 stub)
+# Uses issue link API — MRs linked via "closes #N" or manual links
+glab api projects/:id/issues/<IID>/related_merge_requests --jq '.[] | {iid, source_branch, state, description}'

--- a/claude/skill-references/gitlab/commands/post-code-review.sh
+++ b/claude/skill-references/gitlab/commands/post-code-review.sh
@@ -1,0 +1,3 @@
+# GitLab MR review via notes (v2 stub)
+# Write review body via Write tool, then:
+glab api projects/:id/merge_requests/<IID>/notes -F "body=$(cat <FILE>)"

--- a/claude/skill-references/request-interaction-base.md
+++ b/claude/skill-references/request-interaction-base.md
@@ -8,30 +8,15 @@ Shared logic for `address-request-comments` and `code-review-request`. Skills re
 
 **Read once per session.** Cache the contents after the first read. On subsequent invocations (e.g., polling via `/loop`), skip re-reading unless a new commit modifies this file — the commit SHA check in the quick-exit already detects that.
 
-## Platform Detection
+## Platform Commands
 
-If not already detected this session, read `~/.claude/skill-references/platform-detection.md` and follow its logic to determine GitHub vs GitLab. Set `CLI`, `REVIEW_UNIT`, and API command patterns. Then read the matching platform cluster files:
-- `~/.claude/skill-references/{github,gitlab}/fetch-review-data.md`
-- `~/.claude/skill-references/{github,gitlab}/comment-interaction.md`
-- `~/.claude/skill-references/{github,gitlab}/pr-management.md`
-
-## Platform API Gotchas
-
-After loading platform cluster files, also load platform-specific API learnings to avoid known friction:
-- **GitLab:** Read `~/.claude/learnings-providers.json` to find the team provider's `localPath`, then read `<localPath>/gitlab/gitlab-api-and-cli.md` (if it exists) — covers `glab api` quirks, GraphQL `-F` vs `-f` flag syntax, REST workarounds for nested JSON, and permission-safe patterns for `claude -p` sessions.
-- **GitHub:** No additional learnings load needed — `gh api` patterns are straightforward.
-
-Skip if already loaded this session.
+Platform-specific commands are inlined via `!` preprocessing — the agent sees resolved commands, not references. No platform detection or cluster file loading needed at runtime.
 
 ## Consolidated Fetch
 
-Fetch state + reviews + top-level comments in a single call (GitHub):
-```bash
-gh pr view <number> --json state,reviews,comments,number,title,headRefName,baseRefName
-```
+Fetch state + reviews + top-level comments in a single call:
+!`cat ~/.claude/platform-commands/consolidated-fetch.sh 2>/dev/null || echo "UNCONFIGURED: run setup-claude.sh to set up platform-commands"`
 Parse JSON response — no `--jq` (avoids quoted string permission prompts). Store `REQUEST_NUMBER`, `REQUEST_TITLE`, `HEAD_BRANCH`, `BASE_BRANCH`.
-
-**GitLab equivalent:** `glab mr view <number> -F json -c` (includes discussions; see issue #32 for field mapping).
 
 ## Terminal State Handling
 


### PR DESCRIPTION
## Summary

- Create 8 GitHub platform-command `.sh` scripts (`check-pr-mergeable`, `fetch-pr-base-branch`, `check-issue-state`, `list-prs-by-branch`, `list-prs-by-issue-ref`, `list-open-prs`, `fetch-issue-with-comments`, `post-code-review`)
- Create 8 matching GitLab v2 stubs using `glab api` equivalents
- Scripts follow existing template patterns with `<PLACEHOLDER>` variables for `!cat` inlining

Relates to https://github.com/ahoym/dotfiles/issues/92

Phase 1 of #90.

## Learnings Applied

- `claude-authoring/skill-platform-unification.md` — Nested platform-specific scripts in `github/` and `gitlab/` subdirectories; swept both platforms
- `bash-patterns.md` — Followed existing script template conventions

## Test Plan

- [ ] Verify scripts are syntactically consistent with existing scripts in `github/commands/` and `gitlab/commands/`
- [ ] Verify `!cat` inlining resolves correctly when referenced from skills
- [ ] Spot-check a GitHub command by substituting a real PR/issue number
