### PR TITLE
feat: parameterize entity type in runner template (#91)

### DIFF
--- a/claude/commands/sweep/address-prs/SKILL.md
+++ b/claude/commands/sweep/address-prs/SKILL.md
@@ -232,7 +232,12 @@ Write data files for template assembly, then call `fill-template.sh`:
 
 #### let-it-rip.sh
 
-Follow **let-it-rip.sh Generation** in `sweep-scaffold.md`. Write `<RUN_DIR>/metadata.json` with `MODE` → `address`, `MODEL` → `claude-opus-4-6` (leaf — reads diffs, edits files, pushes commits), `ENTITY_PREFIX` → `"pr"`, `ENTITY_LABEL` → `"PR"`, `STATE_FIELD` → `"pr_state"`, `STATE_CHECK_CMD` → `"gh pr view"`, `TERMINAL_STATES` → `"MERGED CLOSED"`, `BRANCHES` → `"true"`, `WORKTREES` → `"true"`, `PROJECT_ROOT` → absolute path. Also write address-mode data files to `<RUN_DIR>/`:
+Follow **let-it-rip.sh Generation** in `sweep-scaffold.md`. Write `<RUN_DIR>/metadata.json` using the runner schema from sweep-scaffold.md with these address-mode overrides:
+- `MODE` → `"address"`, `MODE_LABEL` → `"Address"`
+- `MODEL` → `"claude-opus-4-6"` (leaf — reads diffs, edits files, pushes commits)
+- `BRANCHES` → `"true"`, `WORKTREES` → `"true"`, `PROJECT_ROOT` → absolute path
+
+All other keys (entity type, `CONCURRENCY`, `RUN_DIR`, `TIMESTAMP`) follow the schema defaults for PRs. Also write address-mode data files to `<RUN_DIR>/`:
 - `branch-cases.txt` — case body lines (e.g., `80) echo "feat/auth" ;;`)
 - `worktree-cases.txt` — case body lines (e.g., `80) echo "/path/to/wt" ;;`)
 - `new-worktree-items.txt` — space-separated PR numbers needing new worktrees

--- a/claude/commands/sweep/address-prs/SKILL.md
+++ b/claude/commands/sweep/address-prs/SKILL.md
@@ -235,7 +235,7 @@ Write data files for template assembly, then call `fill-template.sh`:
 Follow **let-it-rip.sh Generation** in `sweep-scaffold.md`. Write `<RUN_DIR>/metadata.json` with `MODE` → `address`, `MODEL` → `claude-opus-4-6` (leaf — reads diffs, edits files, pushes commits), `ENTITY_PREFIX` → `"pr"`, `ENTITY_LABEL` → `"PR"`, `STATE_FIELD` → `"pr_state"`, `STATE_CHECK_CMD` → `"gh pr view"`, `TERMINAL_STATES` → `"MERGED CLOSED"`, `BRANCHES` → `"true"`, `WORKTREES` → `"true"`, `PROJECT_ROOT` → absolute path. Also write address-mode data files to `<RUN_DIR>/`:
 - `branch-cases.txt` — case body lines (e.g., `80) echo "feat/auth" ;;`)
 - `worktree-cases.txt` — case body lines (e.g., `80) echo "/path/to/wt" ;;`)
-- `new-worktree-prs.txt` — space-separated PR numbers needing new worktrees
+- `new-worktree-items.txt` — space-separated PR numbers needing new worktrees
 
 Then assemble via `fill-template.sh`. The worktree setup loop in the template includes the pre-flight state check before fetching — no manual addition needed.
 

--- a/claude/commands/sweep/address-prs/SKILL.md
+++ b/claude/commands/sweep/address-prs/SKILL.md
@@ -232,7 +232,7 @@ Write data files for template assembly, then call `fill-template.sh`:
 
 #### let-it-rip.sh
 
-Follow **let-it-rip.sh Generation** in `sweep-scaffold.md`. Write `<RUN_DIR>/metadata.json` with `MODE` → `address`, `MODEL` → `claude-opus-4-6` (leaf — reads diffs, edits files, pushes commits), `BRANCHES` → `"true"`, `WORKTREES` → `"true"`, `PROJECT_ROOT` → absolute path. Also write address-mode data files to `<RUN_DIR>/`:
+Follow **let-it-rip.sh Generation** in `sweep-scaffold.md`. Write `<RUN_DIR>/metadata.json` with `MODE` → `address`, `MODEL` → `claude-opus-4-6` (leaf — reads diffs, edits files, pushes commits), `ENTITY_PREFIX` → `"pr"`, `ENTITY_LABEL` → `"PR"`, `STATE_FIELD` → `"pr_state"`, `STATE_CHECK_CMD` → `"gh pr view"`, `TERMINAL_STATES` → `"MERGED CLOSED"`, `BRANCHES` → `"true"`, `WORKTREES` → `"true"`, `PROJECT_ROOT` → absolute path. Also write address-mode data files to `<RUN_DIR>/`:
 - `branch-cases.txt` — case body lines (e.g., `80) echo "feat/auth" ;;`)
 - `worktree-cases.txt` — case body lines (e.g., `80) echo "/path/to/wt" ;;`)
 - `new-worktree-prs.txt` — space-separated PR numbers needing new worktrees

--- a/claude/commands/sweep/address-prs/SKILL.md
+++ b/claude/commands/sweep/address-prs/SKILL.md
@@ -237,10 +237,16 @@ Follow **let-it-rip.sh Generation** in `sweep-scaffold.md`. Write `<RUN_DIR>/met
 - `MODEL` → `"claude-opus-4-6"` (leaf — reads diffs, edits files, pushes commits)
 - `BRANCHES` → `"true"`, `WORKTREES` → `"true"`, `PROJECT_ROOT` → absolute path
 
-All other keys (entity type, `CONCURRENCY`, `RUN_DIR`, `TIMESTAMP`) follow the schema defaults for PRs. Also write address-mode data files to `<RUN_DIR>/`:
+Entity type keys for PRs:
+```json
+{"ENTITY_PREFIX": "pr", "ENTITY_LABEL": "PR", "STATE_FIELD": "pr_state",
+ "STATE_CHECK_CMD": "gh pr view", "TERMINAL_STATES": "MERGED CLOSED"}
+```
+
+All other keys (`CONCURRENCY`, `RUN_DIR`, `TIMESTAMP`) follow the schema defaults. Also write address-mode data files to `<RUN_DIR>/`:
 - `branch-cases.txt` — case body lines (e.g., `80) echo "feat/auth" ;;`)
 - `worktree-cases.txt` — case body lines (e.g., `80) echo "/path/to/wt" ;;`)
-- `new-worktree-items.txt` — space-separated PR numbers needing new worktrees
+- `new-worktree-items.txt` — space-separated entity numbers needing new worktrees
 
 Then assemble via `fill-template.sh`. The worktree setup loop in the template includes the pre-flight state check before fetching — no manual addition needed.
 

--- a/claude/commands/sweep/review-prs/SKILL.md
+++ b/claude/commands/sweep/review-prs/SKILL.md
@@ -196,7 +196,12 @@ Write data files for template assembly, then call `fill-template.sh`:
 
 #### let-it-rip.sh
 
-Follow **let-it-rip.sh Generation** in `sweep-scaffold.md`. Write `<RUN_DIR>/metadata.json` with `MODE` → `review`, `MODEL` → `claude-sonnet-4-6` (orchestrator — heavy work is in `git:team-review-request`'s subagents), `ENTITY_PREFIX` → `"pr"`, `ENTITY_LABEL` → `"PR"`, `STATE_FIELD` → `"pr_state"`, `STATE_CHECK_CMD` → `"gh pr view"`, `TERMINAL_STATES` → `"MERGED CLOSED"`, `BRANCHES` → `""`, `WORKTREES` → `""` (review mode doesn't use worktrees). Then assemble via `fill-template.sh`.
+Follow **let-it-rip.sh Generation** in `sweep-scaffold.md`. Write `<RUN_DIR>/metadata.json` using the runner schema from sweep-scaffold.md with these review-mode overrides:
+- `MODE` → `"review"`, `MODE_LABEL` → `"Review"`
+- `MODEL` → `"claude-sonnet-4-6"` (orchestrator — heavy work is in `git:team-review-request`'s subagents)
+- `BRANCHES` → `""`, `WORKTREES` → `""` (review mode doesn't use worktrees)
+
+All other keys (entity type, `CONCURRENCY`, `RUN_DIR`, `TIMESTAMP`) follow the schema defaults for PRs. Then assemble via `fill-template.sh`.
 
 ### Phase 7: Announce, Progress Check, Retro
 

--- a/claude/commands/sweep/review-prs/SKILL.md
+++ b/claude/commands/sweep/review-prs/SKILL.md
@@ -201,7 +201,13 @@ Follow **let-it-rip.sh Generation** in `sweep-scaffold.md`. Write `<RUN_DIR>/met
 - `MODEL` → `"claude-sonnet-4-6"` (orchestrator — heavy work is in `git:team-review-request`'s subagents)
 - `BRANCHES` → `""`, `WORKTREES` → `""` (review mode doesn't use worktrees)
 
-All other keys (entity type, `CONCURRENCY`, `RUN_DIR`, `TIMESTAMP`) follow the schema defaults for PRs. Then assemble via `fill-template.sh`.
+Entity type keys for PRs:
+```json
+{"ENTITY_PREFIX": "pr", "ENTITY_LABEL": "PR", "STATE_FIELD": "pr_state",
+ "STATE_CHECK_CMD": "gh pr view", "TERMINAL_STATES": "MERGED CLOSED"}
+```
+
+All other keys (`CONCURRENCY`, `RUN_DIR`, `TIMESTAMP`) follow the schema defaults. Then assemble via `fill-template.sh`.
 
 ### Phase 7: Announce, Progress Check, Retro
 

--- a/claude/commands/sweep/review-prs/SKILL.md
+++ b/claude/commands/sweep/review-prs/SKILL.md
@@ -196,7 +196,7 @@ Write data files for template assembly, then call `fill-template.sh`:
 
 #### let-it-rip.sh
 
-Follow **let-it-rip.sh Generation** in `sweep-scaffold.md`. Write `<RUN_DIR>/metadata.json` with `MODE` → `review`, `MODEL` → `claude-sonnet-4-6` (orchestrator — heavy work is in `git:team-review-request`'s subagents), `BRANCHES` → `""`, `WORKTREES` → `""` (review mode doesn't use worktrees). Then assemble via `fill-template.sh`.
+Follow **let-it-rip.sh Generation** in `sweep-scaffold.md`. Write `<RUN_DIR>/metadata.json` with `MODE` → `review`, `MODEL` → `claude-sonnet-4-6` (orchestrator — heavy work is in `git:team-review-request`'s subagents), `ENTITY_PREFIX` → `"pr"`, `ENTITY_LABEL` → `"PR"`, `STATE_FIELD` → `"pr_state"`, `STATE_CHECK_CMD` → `"gh pr view"`, `TERMINAL_STATES` → `"MERGED CLOSED"`, `BRANCHES` → `""`, `WORKTREES` → `""` (review mode doesn't use worktrees). Then assemble via `fill-template.sh`.
 
 ### Phase 7: Announce, Progress Check, Retro
 

--- a/claude/commands/sweep/work-items/SKILL.md
+++ b/claude/commands/sweep/work-items/SKILL.md
@@ -268,12 +268,11 @@ Write data files for template assembly, then call `fill-template.sh`:
 Generate a runner script adapted for work items. Follow **let-it-rip.sh Generation** in `sweep-scaffold.md` — write `<RUN_DIR>/metadata.json` and assemble via `fill-template.sh`. Do NOT read the runner template directly. Work-item-specific metadata overrides and adaptations:
 
 - **Model selection**: `MODEL` → `claude-opus-4-6` for implement runs (leaf doing actual coding work). Clarify and confirm runs may use `claude-sonnet-4-6` (lighter, comment-driven). When mixing modes in one runner, default to opus.
-- **Directory naming**: `issue-<N>` instead of `pr-<N>`
-- **Config section**: `ISSUES=(<numbers>)` instead of `PRS`, `IMPLEMENT_ISSUES=(<numbers>)` for worktree tracking
+- **Entity type keys**: `ENTITY_PREFIX` → `"issue"`, `ENTITY_LABEL` → `"Issue"`, `STATE_FIELD` → `"issue_state"`, `STATE_CHECK_CMD` → `"gh issue view"`, `TERMINAL_STATES` → `"CLOSED"`.
 - **Worktree setup**: Only for issues in `IMPLEMENT_ISSUES`. Create worktrees under `<RUN_DIR>/worktrees/issue-<N>/` from the issue's `BASE_BRANCH` (read from `metadata.json`). When `BASE_BRANCH` is the default branch, the implementer starts fresh. When it's a dependency's PR branch, the implementer stacks on top of that branch's work. **For non-default base branches:** run `git fetch origin <BASE_BRANCH>` before `git worktree add` — the dependency's branch likely only exists on the remote.
 - **PR target for stacked branches**: When `BASE_BRANCH` is not the default branch, the implementer's PR must target `BASE_BRANCH` (not main). The `BASE_BRANCH` value is available in `metadata.json` and must be passed through to the implementer prompt so `gh pr create --base <BASE_BRANCH>` is used.
 - **Pre-flight state check**:
-  1. Local `status.md` check — skip if `issue_state: closed` or `pr_opened: true` or `comment_posted: true`
+  1. Local `status.md` check — skip if `issue_state: CLOSED` (terminal entity state only — role convergence signals like `comment_posted` and `pr_opened` are the session's responsibility, not the runner's)
   2. API fallback — `gh issue view <N> --json state -q '.state'`, skip if closed
 - **Working directory**: For implementers, `cd` into the worktree before launching `claude -p`. For clarifiers, stay in project root.
 - **Cleanup**: Worktree cleanup on EXIT trap (only for worktrees created by this run).

--- a/claude/commands/sweep/work-items/SKILL.md
+++ b/claude/commands/sweep/work-items/SKILL.md
@@ -268,7 +268,12 @@ Write data files for template assembly, then call `fill-template.sh`:
 Generate a runner script adapted for work items. Follow **let-it-rip.sh Generation** in `sweep-scaffold.md` — write `<RUN_DIR>/metadata.json` and assemble via `fill-template.sh`. Do NOT read the runner template directly. Work-item-specific metadata overrides and adaptations:
 
 - **Model selection**: `MODEL` → `claude-opus-4-6` for implement runs (leaf doing actual coding work). Clarify and confirm runs may use `claude-sonnet-4-6` (lighter, comment-driven). When mixing modes in one runner, default to opus.
-- **Entity type keys**: `ENTITY_PREFIX` → `"issue"`, `ENTITY_LABEL` → `"Issue"`, `STATE_FIELD` → `"issue_state"`, `STATE_CHECK_CMD` → `"gh issue view"`, `TERMINAL_STATES` → `"CLOSED"`.
+- **Entity type keys**: Set in `metadata.json` per the sweep-scaffold.md schema. Issue-specific values:
+  ```json
+  {"ENTITY_PREFIX": "issue", "ENTITY_LABEL": "Issue", "STATE_FIELD": "issue_state",
+   "STATE_CHECK_CMD": "gh issue view", "TERMINAL_STATES": "CLOSED"}
+  ```
+- **Config arrays**: `IMPLEMENT_ISSUES=(<numbers>)` — issues that get worktrees vs in-place clarifiers. Write this array to the runner script so the worktree setup section knows which issues need checkouts.
 - **Worktree setup**: Only for issues in `IMPLEMENT_ISSUES`. Create worktrees under `<RUN_DIR>/worktrees/issue-<N>/` from the issue's `BASE_BRANCH` (read from `metadata.json`). When `BASE_BRANCH` is the default branch, the implementer starts fresh. When it's a dependency's PR branch, the implementer stacks on top of that branch's work. **For non-default base branches:** run `git fetch origin <BASE_BRANCH>` before `git worktree add` — the dependency's branch likely only exists on the remote.
 - **PR target for stacked branches**: When `BASE_BRANCH` is not the default branch, the implementer's PR must target `BASE_BRANCH` (not main). The `BASE_BRANCH` value is available in `metadata.json` and must be passed through to the implementer prompt so `gh pr create --base <BASE_BRANCH>` is used.
 - **Pre-flight state check**:

--- a/claude/skill-references/parallel-claude-runner-template.sh
+++ b/claude/skill-references/parallel-claude-runner-template.sh
@@ -13,7 +13,7 @@ RUN_DIR="{{RUN_DIR}}"           # absolute path
 CONCURRENCY={{CONCURRENCY}}
 INACTIVITY_TIMEOUT_SEC=${INACTIVITY_TIMEOUT:-600}
 MAX_ATTEMPTS=2
-PRS=({{PRS}})                   # space-separated PR numbers
+ITEMS=({{ITEMS}})               # space-separated entity numbers (PR or issue)
 MODE="{{MODE}}"                 # "review" or "address"
 MODE_LABEL="{{MODE_LABEL}}"     # "Review" or "Address" (pre-capitalized for bash 3.x)
 MODEL="${MODEL:-{{MODEL}}}"     # claude model — runtime env override supported
@@ -36,26 +36,26 @@ worktree_for() {
     esac
 }
 # PRs that need new worktrees (empty if all reused)
-NEW_WORKTREE_PRS=({@new-worktree-prs.txt})
+NEW_WORKTREE_ITEMS=({@new-worktree-items.txt})
 PROJECT_ROOT="{{PROJECT_ROOT}}"
 {{/BRANCHES}}
 
 # --- Worktree setup (address mode only) ---
 {{#WORKTREES}}
 setup_worktrees() {
-    if [ ${#NEW_WORKTREE_PRS[@]} -eq 0 ]; then
+    if [ ${#NEW_WORKTREE_ITEMS[@]} -eq 0 ]; then
         echo "All worktrees reused from existing checkouts."
         return
     fi
     mkdir -p "$RUN_DIR/worktrees"
-    for pr_num in "${NEW_WORKTREE_PRS[@]}"; do
+    for item_num in "${NEW_WORKTREE_ITEMS[@]}"; do
         local branch
-        branch=$(branch_for "$pr_num")
+        branch=$(branch_for "$item_num")
         local wt
-        wt=$(worktree_for "$pr_num")
+        wt=$(worktree_for "$item_num")
         if [ ! -d "$wt" ]; then
             git -C "$PROJECT_ROOT" worktree add "$wt" "$branch" || {
-                echo "WARNING: Failed to create worktree for PR $pr_num, skipping"
+                echo "WARNING: Failed to create worktree for ${ENTITY_LABEL} $item_num, skipping"
                 continue
             }
         else
@@ -66,9 +66,9 @@ setup_worktrees() {
 
 cleanup_worktrees() {
     # Only clean up worktrees we created, not pre-existing ones
-    for pr_num in "${NEW_WORKTREE_PRS[@]}"; do
+    for item_num in "${NEW_WORKTREE_ITEMS[@]}"; do
         local wt
-        wt=$(worktree_for "$pr_num")
+        wt=$(worktree_for "$item_num")
         git -C "$PROJECT_ROOT" worktree remove "$wt" --force 2>/dev/null || true
     done
 }
@@ -82,7 +82,7 @@ echo ====================================================
 echo "Sweep ${MODE_LABEL} Runner"
 echo ====================================================
 echo "Run directory: $RUN_DIR"
-echo "PRs:           ${PRS[*]}"
+echo "${ENTITY_LABEL}s:         ${ITEMS[*]}"
 echo "Concurrency:   $CONCURRENCY"
 echo "Started at:    $(date)"
 echo ====================================================
@@ -102,16 +102,16 @@ if [ -f "${RUN_DIR}/manifest-updates.json" ]; then
         action=$(printf '%s' "$line" | jq -r '.action // empty' 2>/dev/null) || continue
         item_id=$(printf '%s' "$line" | jq -r '.id // .item.id // empty' 2>/dev/null) || continue
         if [ "$action" = "add" ] && [ -n "$item_id" ]; then
-            # Dedup: skip if already in PRS array
+            # Dedup: skip if already in ITEMS array
             local already_present=false
-            for existing in "${PRS[@]}"; do
+            for existing in "${ITEMS[@]}"; do
                 if [ "$existing" = "$item_id" ]; then
                     already_present=true
                     break
                 fi
             done
             if [ "$already_present" = false ] && [ -f "${RUN_DIR}/${ENTITY_PREFIX}-${item_id}/prompt.txt" ]; then
-                PRS+=("$item_id")
+                ITEMS+=("$item_id")
             fi
         elif [ "$action" = "close" ] && [ -n "$item_id" ]; then
             close_reason=$(printf '%s' "$line" | jq -r '.reason // empty' 2>/dev/null)
@@ -125,8 +125,8 @@ fi
 
 # --- State writer ---
 write_state() {
-    local pr_num=$1 state=$2
-    local pr_dir="${RUN_DIR}/${ENTITY_PREFIX}-${pr_num}"
+    local item_num=$1 state=$2
+    local item_dir="${RUN_DIR}/${ENTITY_PREFIX}-${item_num}"
     local now
     now=$(date -Iseconds 2>/dev/null || date +%Y-%m-%dT%H:%M:%S%z)
     {
@@ -137,7 +137,7 @@ write_state() {
             printf '%s\n' "$1"
             shift
         done
-    } > "${pr_dir}/state.md"
+    } > "${item_dir}/state.md"
 }
 
 # --- Terminal state check ---
@@ -151,11 +151,11 @@ is_terminal_state() {
 }
 
 # --- Per-PR function ---
-process_pr() {
-    local pr_num=$1
-    local pr_dir="${RUN_DIR}/${ENTITY_PREFIX}-${pr_num}"
-    local log_file="${pr_dir}/output.log"
-    local status_file="${pr_dir}/status.md"
+process_item() {
+    local item_num=$1
+    local item_dir="${RUN_DIR}/${ENTITY_PREFIX}-${item_num}"
+    local log_file="${item_dir}/output.log"
+    local status_file="${item_dir}/status.md"
     local start_time=$(date +%s)
     local ts=$(date +%H:%M:%S)
 
@@ -167,38 +167,38 @@ process_pr() {
         local cached_state
         cached_state=$(grep "^${STATE_FIELD}:" "$status_file" 2>/dev/null | awk '{print $2}')
         if is_terminal_state "$cached_state"; then
-            echo "[$ts] ${ENTITY_LABEL} #${pr_num}: SKIPPED ($cached_state, from status.md)"
+            echo "[$ts] ${ENTITY_LABEL} #${item_num}: SKIPPED ($cached_state, from status.md)"
             return
         fi
     fi
 
     # Pre-flight: skip if rate-limited (after terminal check so completed sessions aren't regressed)
     if [ -f "${RUN_DIR}/.rate-limited" ]; then
-        printf '# %s #%s\nmilestone: skipped\nreason: rate-limited\n' "$ENTITY_LABEL" "$pr_num" > "$status_file"
-        echo "[$ts] ${ENTITY_LABEL} #${pr_num}: SKIPPED (rate-limited)"
+        printf '# %s #%s\nmilestone: skipped\nreason: rate-limited\n' "$ENTITY_LABEL" "$item_num" > "$status_file"
+        echo "[$ts] ${ENTITY_LABEL} #${item_num}: SKIPPED (rate-limited)"
         return
     fi
 
     # Pre-flight: skip terminal entities (API fallback for first run or missing status.md)
     local state
-    state=$($STATE_CHECK_CMD "$pr_num" --json state -q '.state' 2>/dev/null || echo "UNKNOWN")
+    state=$($STATE_CHECK_CMD "$item_num" --json state -q '.state' 2>/dev/null || echo "UNKNOWN")
     if is_terminal_state "$state" || [ "$state" = "UNKNOWN" ]; then
-        printf '# %s #%s\nmilestone: skipped\nreason: %s\n%s: %s\n' "$ENTITY_LABEL" "$pr_num" "$state" "$STATE_FIELD" "$state" > "$status_file"
-        echo "[$ts] ${ENTITY_LABEL} #${pr_num}: SKIPPED ($state)"
+        printf '# %s #%s\nmilestone: skipped\nreason: %s\n%s: %s\n' "$ENTITY_LABEL" "$item_num" "$state" "$STATE_FIELD" "$state" > "$status_file"
+        echo "[$ts] ${ENTITY_LABEL} #${item_num}: SKIPPED ($state)"
         return
     fi
 
-    echo "[$ts] ${ENTITY_LABEL} #${pr_num}: launching claude -p session..."
+    echo "[$ts] ${ENTITY_LABEL} #${item_num}: launching claude -p session..."
     printf '# %s #%s Status\nmilestone: launching\nstarted_at: %s\n' \
-        "$ENTITY_LABEL" "$pr_num" "$(date -Iseconds)" > "$status_file"
+        "$ENTITY_LABEL" "$item_num" "$(date -Iseconds)" > "$status_file"
 
     # Archive previous cycle's raw.jsonl (raw-1.jsonl, raw-2.jsonl, ...)
-    if [ -f "$pr_dir/raw.jsonl" ]; then
+    if [ -f "$item_dir/raw.jsonl" ]; then
         local archive_num=1
-        while [ -f "${pr_dir}/raw-${archive_num}.jsonl" ]; do
+        while [ -f "${item_dir}/raw-${archive_num}.jsonl" ]; do
             archive_num=$((archive_num + 1))
         done
-        mv "$pr_dir/raw.jsonl" "${pr_dir}/raw-${archive_num}.jsonl"
+        mv "$item_dir/raw.jsonl" "${item_dir}/raw-${archive_num}.jsonl"
     fi
 
     # Determine launch mode: resume or fresh start
@@ -208,28 +208,28 @@ process_pr() {
     local cycle=1
     local prev_cost_usd=0
 
-    if [ -f "$pr_dir/session.reset" ]; then
-        rm -f "$pr_dir/session.state" "$pr_dir/session.reset"
-    elif [ -f "$pr_dir/session.state" ]; then
+    if [ -f "$item_dir/session.reset" ]; then
+        rm -f "$item_dir/session.state" "$item_dir/session.reset"
+    elif [ -f "$item_dir/session.state" ]; then
         local state_mtime
-        state_mtime=$(stat -f%m "$pr_dir/session.state" 2>/dev/null \
-            || stat -c%Y "$pr_dir/session.state" 2>/dev/null || echo 0)
+        state_mtime=$(stat -f%m "$item_dir/session.state" 2>/dev/null \
+            || stat -c%Y "$item_dir/session.state" 2>/dev/null || echo 0)
         local state_age=$(( $(date +%s) - state_mtime ))
         if [ "$state_age" -lt 21600 ]; then
-            resume_session_id=$(grep '^session_id=' "$pr_dir/session.state" | cut -d= -f2)
-            prev_cost_usd=$(grep '^prev_cost_usd=' "$pr_dir/session.state" | cut -d= -f2 || echo 0)
-            cycle=$(grep '^cycle=' "$pr_dir/session.state" | cut -d= -f2 || echo 1)
+            resume_session_id=$(grep '^session_id=' "$item_dir/session.state" | cut -d= -f2)
+            prev_cost_usd=$(grep '^prev_cost_usd=' "$item_dir/session.state" | cut -d= -f2 || echo 0)
+            cycle=$(grep '^cycle=' "$item_dir/session.state" | cut -d= -f2 || echo 1)
             if [ -n "$resume_session_id" ]; then
                 use_resume=true
                 resume_flag="--resume $resume_session_id"
             fi
         else
-            rm -f "$pr_dir/session.state"
+            rm -f "$item_dir/session.state"
         fi
     fi
 
     # Append cycle boundary to live.md so director can distinguish cycles
-    printf '\n### Cycle %d — %s ###\n' "$cycle" "$(date -Iseconds)" >> "$pr_dir/live.md"
+    printf '\n### Cycle %d — %s ###\n' "$cycle" "$(date -Iseconds)" >> "$item_dir/live.md"
 
     # Resolve stream monitor path (works from any CWD via HOME)
     local monitor="${HOME}/.claude/skill-references/stream-monitor.sh"
@@ -240,11 +240,11 @@ process_pr() {
         local exit_status=""
         local attempt_start=$(date +%s)
 
-        write_state "$pr_num" "running" "attempt: $attempt" "max_attempts: $MAX_ATTEMPTS" "started_at: $(date -Iseconds)"
+        write_state "$item_num" "running" "attempt: $attempt" "max_attempts: $MAX_ATTEMPTS" "started_at: $(date -Iseconds)"
 
         # Add attempt boundary marker for raw.jsonl (append-only across retries)
         if [ "$attempt" -gt 1 ]; then
-            printf '### attempt %d ###\n' "$attempt" >> "$pr_dir/raw.jsonl"
+            printf '### attempt %d ###\n' "$attempt" >> "$item_dir/raw.jsonl"
         fi
 
         # Launch with stream monitoring if monitor exists, otherwise fall back to plain pipe
@@ -253,28 +253,28 @@ process_pr() {
                 if [ "$use_resume" = true ]; then
                     printf 'Cycle %d. Check directives.md for new directives since your last run. Continue.' "$cycle"
                 else
-                    cat "${pr_dir}/prompt.txt"
+                    cat "${item_dir}/prompt.txt"
                 fi
             } \
-                | sh -c "echo \$\$ > ${pr_dir}/session.pid; exec claude -p --model $MODEL --verbose --output-format stream-json $resume_flag" \
-                | "$monitor" "$pr_dir" \
-                | tee -a "$pr_dir/raw.jsonl" >> "$log_file" &
+                | sh -c "echo \$\$ > ${item_dir}/session.pid; exec claude -p --model $MODEL --verbose --output-format stream-json $resume_flag" \
+                | "$monitor" "$item_dir" \
+                | tee -a "$item_dir/raw.jsonl" >> "$log_file" &
             local pipe_pid=$!
 
             # Inactivity monitoring loop
             while kill -0 "$pipe_pid" 2>/dev/null; do
                 sleep 30
                 local now_epoch=$(date +%s)
-                local live_file="${pr_dir}/live.md"
+                local live_file="${item_dir}/live.md"
                 if [ -f "$live_file" ]; then
                     local live_mtime
                     live_mtime=$(stat -c %Y "$live_file" 2>/dev/null || stat -f %m "$live_file" 2>/dev/null || echo "$now_epoch")
                     local idle_seconds=$((now_epoch - live_mtime))
                     if [ "$idle_seconds" -gt "$INACTIVITY_TIMEOUT_SEC" ]; then
-                        echo "[$(date +%H:%M:%S)] ${ENTITY_LABEL} #${pr_num}: inactivity timeout (${idle_seconds}s idle, attempt ${attempt}/${MAX_ATTEMPTS})"
+                        echo "[$(date +%H:%M:%S)] ${ENTITY_LABEL} #${item_num}: inactivity timeout (${idle_seconds}s idle, attempt ${attempt}/${MAX_ATTEMPTS})"
                         # Kill the claude session
-                        if [ -f "${pr_dir}/session.pid" ]; then
-                            kill "$(cat "${pr_dir}/session.pid")" 2>/dev/null || true
+                        if [ -f "${item_dir}/session.pid" ]; then
+                            kill "$(cat "${item_dir}/session.pid")" 2>/dev/null || true
                         fi
                         kill "$pipe_pid" 2>/dev/null || true
                         wait "$pipe_pid" 2>/dev/null || true
@@ -294,7 +294,7 @@ process_pr() {
             fi
         else
             local fallback_timeout=$((INACTIVITY_TIMEOUT_SEC * 2))
-            if timeout "$fallback_timeout" sh -c "cat \"\$1\" | claude -p --model $MODEL 2>&1 | tee -a \"\$2\"" _ "${pr_dir}/prompt.txt" "$log_file"; then
+            if timeout "$fallback_timeout" sh -c "cat \"\$1\" | claude -p --model $MODEL 2>&1 | tee -a \"\$2\"" _ "${item_dir}/prompt.txt" "$log_file"; then
                 exit_status="success"
             else
                 local fallback_rc=$?
@@ -312,14 +312,14 @@ process_pr() {
 
         # Handle exit status — success takes priority over transient rate limits
         if [ "$exit_status" = "success" ]; then
-            echo "[$end_ts] ${ENTITY_LABEL} #${pr_num}: DONE (${duration}s, attempt ${attempt}/${MAX_ATTEMPTS})"
+            echo "[$end_ts] ${ENTITY_LABEL} #${item_num}: DONE (${duration}s, attempt ${attempt}/${MAX_ATTEMPTS})"
 
             # Compute context window usage from the latest assistant message's usage block.
             # cache_read + cache_creation + input_tokens = total tokens the model processed this turn,
             # which equals the conversation context size at that point.
             local context_used=0 context_pct=0 context_window=200000
             local last_usage
-            last_usage=$(jq -c 'select(.type == "assistant") | .message.usage // empty' "$pr_dir/raw.jsonl" 2>/dev/null | tail -1)
+            last_usage=$(jq -c 'select(.type == "assistant") | .message.usage // empty' "$item_dir/raw.jsonl" 2>/dev/null | tail -1)
             if [ -n "$last_usage" ]; then
                 local in_tok cc_tok cr_tok
                 in_tok=$(printf '%s' "$last_usage" | jq -r '.input_tokens // 0')
@@ -334,7 +334,7 @@ process_pr() {
                 context_pct=$((context_used * 100 / context_window))
             fi
 
-            write_state "$pr_num" "completed" \
+            write_state "$item_num" "completed" \
                 "attempt: $attempt" \
                 "max_attempts: $MAX_ATTEMPTS" \
                 "duration_seconds: $duration" \
@@ -344,14 +344,14 @@ process_pr() {
 
             # Persist session state for next cycle (resume support)
             local result_line
-            result_line=$(jq -c 'select(.type == "result" and .subtype == "success")' "$pr_dir/raw.jsonl" 2>/dev/null | tail -1)
+            result_line=$(jq -c 'select(.type == "result" and .subtype == "success")' "$item_dir/raw.jsonl" 2>/dev/null | tail -1)
             if [ -n "$result_line" ]; then
                 local new_session_id new_cost_usd
                 new_session_id=$(printf '%s' "$result_line" | jq -r '.session_id // empty')
                 new_cost_usd=$(printf '%s' "$result_line" | jq -r '.total_cost_usd // 0')
                 if [ -n "$new_session_id" ]; then
                     printf 'session_id=%s\nprev_cost_usd=%s\ncycle=%d\n' \
-                        "$new_session_id" "$new_cost_usd" "$((cycle + 1))" > "$pr_dir/session.state"
+                        "$new_session_id" "$new_cost_usd" "$((cycle + 1))" > "$item_dir/session.state"
                 fi
             fi
             return
@@ -360,16 +360,16 @@ process_pr() {
         # Rate limit detection (only on failure — transient limits during successful sessions are harmless)
         if grep -q "hit your limit" "$log_file" 2>/dev/null; then
             exit_status="rate-limited"
-            printf '# %s #%s Status\nmilestone: rate-limited\n' "$ENTITY_LABEL" "$pr_num" > "$status_file"
+            printf '# %s #%s Status\nmilestone: rate-limited\n' "$ENTITY_LABEL" "$item_num" > "$status_file"
             touch "${RUN_DIR}/.rate-limited"
-            write_state "$pr_num" "rate-limited" "attempt: $attempt" "max_attempts: $MAX_ATTEMPTS"
+            write_state "$item_num" "rate-limited" "attempt: $attempt" "max_attempts: $MAX_ATTEMPTS"
             break
         fi
 
         # Resume fallback: if session not found, switch to fresh start (don't count as an attempt)
-        if [ "$use_resume" = true ] && grep -q "No conversation found" "$pr_dir/raw.jsonl" 2>/dev/null; then
-            echo "[$end_ts] ${ENTITY_LABEL} #${pr_num}: resume session expired — falling back to fresh start"
-            rm -f "$pr_dir/session.state"
+        if [ "$use_resume" = true ] && grep -q "No conversation found" "$item_dir/raw.jsonl" 2>/dev/null; then
+            echo "[$end_ts] ${ENTITY_LABEL} #${item_num}: resume session expired — falling back to fresh start"
+            rm -f "$item_dir/session.state"
             use_resume=false
             resume_session_id=""
             resume_flag=""
@@ -380,26 +380,26 @@ process_pr() {
 
         # Failure — retry or escalate
         if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
-            echo "[$end_ts] ${ENTITY_LABEL} #${pr_num}: FAILED (${duration}s, attempt ${attempt}/${MAX_ATTEMPTS}) — retrying in 5s..."
-            write_state "$pr_num" "retrying" "attempt: $attempt" "max_attempts: $MAX_ATTEMPTS" "previous_exit: $exit_status"
+            echo "[$end_ts] ${ENTITY_LABEL} #${item_num}: FAILED (${duration}s, attempt ${attempt}/${MAX_ATTEMPTS}) — retrying in 5s..."
+            write_state "$item_num" "retrying" "attempt: $attempt" "max_attempts: $MAX_ATTEMPTS" "previous_exit: $exit_status"
             sleep 5
             continue
         fi
 
         # Final attempt exhausted
-        echo "[$end_ts] ${ENTITY_LABEL} #${pr_num}: ERRORED (${duration}s, attempt ${attempt}/${MAX_ATTEMPTS})"
+        echo "[$end_ts] ${ENTITY_LABEL} #${item_num}: ERRORED (${duration}s, attempt ${attempt}/${MAX_ATTEMPTS})"
         printf '# %s #%s Status\nmilestone: errored\nerror: %s after %d attempts\n' \
-            "$ENTITY_LABEL" "$pr_num" "$exit_status" "$MAX_ATTEMPTS" > "$status_file"
-        write_state "$pr_num" "errored" "attempt: $attempt" "max_attempts: $MAX_ATTEMPTS" "exit_reason: $exit_status" "escalation: needs-director"
+            "$ENTITY_LABEL" "$item_num" "$exit_status" "$MAX_ATTEMPTS" > "$status_file"
+        write_state "$item_num" "errored" "attempt: $attempt" "max_attempts: $MAX_ATTEMPTS" "exit_reason: $exit_status" "escalation: needs-director"
         return
     done
 }
 
-export -f process_pr write_state is_terminal_state
+export -f process_item write_state is_terminal_state
 export RUN_DIR INACTIVITY_TIMEOUT_SEC MAX_ATTEMPTS MODEL MODE_LABEL ENTITY_PREFIX ENTITY_LABEL STATE_FIELD STATE_CHECK_CMD TERMINAL_STATES
 
 # --- Launch ---
-printf '%s\n' "${PRS[@]}" | xargs -P "$CONCURRENCY" -I {} bash -c 'process_pr "$@"' _ {}
+printf '%s\n' "${ITEMS[@]}" | xargs -P "$CONCURRENCY" -I {} bash -c 'process_item "$@"' _ {}
 
 # --- Summary ---
 OVERALL_END=$(date +%s)

--- a/claude/skill-references/parallel-claude-runner-template.sh
+++ b/claude/skill-references/parallel-claude-runner-template.sh
@@ -20,7 +20,7 @@ MODEL="${MODEL:-{{MODEL}}}"     # claude model — runtime env override supporte
 ENTITY_PREFIX="{{ENTITY_PREFIX}}"     # "pr" or "issue" — controls directory naming
 ENTITY_LABEL="{{ENTITY_LABEL}}"       # "PR" or "Issue" — controls log labels
 STATE_FIELD="{{STATE_FIELD}}"         # "pr_state" or "issue_state" — status.md field name
-STATE_CHECK_CMD="{{STATE_CHECK_CMD}}" # "gh pr view" or "gh issue view" — word-split intentionally; must be "<tool> <subcommand>" only, no embedded flags
+STATE_CHECK_CMD="{{STATE_CHECK_CMD}}" # "gh pr view" / "glab mr view" or "gh issue view" / "glab issue view" — word-split intentionally; must be "<tool> <subcommand>" only, no embedded flags
 TERMINAL_STATES="{{TERMINAL_STATES}}" # space-separated single-word state tokens (word-boundary matched by is_terminal_state)
 {{#BRANCHES}}
 # Branch mapping (address mode only — function for bash 3.x compat on macOS)
@@ -150,7 +150,7 @@ is_terminal_state() {
     esac
 }
 
-# --- Per-PR function ---
+# --- Per-item function ---
 process_item() {
     local item_num=$1
     local item_dir="${RUN_DIR}/${ENTITY_PREFIX}-${item_num}"
@@ -182,7 +182,12 @@ process_item() {
     # Pre-flight: skip terminal entities (API fallback for first run or missing status.md)
     local state
     state=$($STATE_CHECK_CMD "$item_num" --json state -q '.state' 2>/dev/null || echo "UNKNOWN")
-    if is_terminal_state "$state" || [ "$state" = "UNKNOWN" ]; then
+    if [ "$state" = "UNKNOWN" ]; then
+        printf '# %s #%s\nmilestone: api-error\nreason: state-check-failed\n%s: UNKNOWN\n' "$ENTITY_LABEL" "$item_num" "$STATE_FIELD" > "$status_file"
+        echo "[$ts] ${ENTITY_LABEL} #${item_num}: SKIPPED (api-error)"
+        return
+    fi
+    if is_terminal_state "$state"; then
         printf '# %s #%s\nmilestone: skipped\nreason: %s\n%s: %s\n' "$ENTITY_LABEL" "$item_num" "$state" "$STATE_FIELD" "$state" > "$status_file"
         echo "[$ts] ${ENTITY_LABEL} #${item_num}: SKIPPED ($state)"
         return

--- a/claude/skill-references/parallel-claude-runner-template.sh
+++ b/claude/skill-references/parallel-claude-runner-template.sh
@@ -20,8 +20,8 @@ MODEL="${MODEL:-{{MODEL}}}"     # claude model — runtime env override supporte
 ENTITY_PREFIX="{{ENTITY_PREFIX}}"     # "pr" or "issue" — controls directory naming
 ENTITY_LABEL="{{ENTITY_LABEL}}"       # "PR" or "Issue" — controls log labels
 STATE_FIELD="{{STATE_FIELD}}"         # "pr_state" or "issue_state" — status.md field name
-STATE_CHECK_CMD="{{STATE_CHECK_CMD}}" # "gh pr view" or "gh issue view" — API pre-flight
-TERMINAL_STATES="{{TERMINAL_STATES}}" # "MERGED CLOSED" or "CLOSED" — pre-flight skip states
+STATE_CHECK_CMD="{{STATE_CHECK_CMD}}" # "gh pr view" or "gh issue view" — word-split intentionally; must be "<tool> <subcommand>" only, no embedded flags
+TERMINAL_STATES="{{TERMINAL_STATES}}" # space-separated single-word state tokens (word-boundary matched by is_terminal_state)
 {{#BRANCHES}}
 # Branch mapping (address mode only — function for bash 3.x compat on macOS)
 branch_for() {
@@ -116,8 +116,8 @@ if [ -f "${RUN_DIR}/manifest-updates.json" ]; then
         elif [ "$action" = "close" ] && [ -n "$item_id" ]; then
             close_reason=$(printf '%s' "$line" | jq -r '.reason // empty' 2>/dev/null)
             mkdir -p "${RUN_DIR}/${ENTITY_PREFIX}-${item_id}"
-            printf '# %s #%s\nmilestone: closed\nreason: %s\n%s: %s\n' \
-                "$ENTITY_LABEL" "$item_id" "${close_reason:-director-closed}" "$STATE_FIELD" "${close_reason:-CLOSED}" \
+            printf '# %s #%s\nmilestone: closed\nreason: %s\n%s: CLOSED\n' \
+                "$ENTITY_LABEL" "$item_id" "${close_reason:-director-closed}" "$STATE_FIELD" \
                 > "${RUN_DIR}/${ENTITY_PREFIX}-${item_id}/status.md"
         fi
     done < "${RUN_DIR}/manifest-updates.json"
@@ -143,6 +143,7 @@ write_state() {
 # --- Terminal state check ---
 is_terminal_state() {
     local state=$1
+    [ -z "$state" ] && return 1
     case " $TERMINAL_STATES " in
         *" $state "*) return 0 ;;
         *) return 1 ;;
@@ -181,7 +182,7 @@ process_pr() {
     # Pre-flight: skip terminal entities (API fallback for first run or missing status.md)
     local state
     state=$($STATE_CHECK_CMD "$pr_num" --json state -q '.state' 2>/dev/null || echo "UNKNOWN")
-    if is_terminal_state "$state"; then
+    if is_terminal_state "$state" || [ "$state" = "UNKNOWN" ]; then
         printf '# %s #%s\nmilestone: skipped\nreason: %s\n%s: %s\n' "$ENTITY_LABEL" "$pr_num" "$state" "$STATE_FIELD" "$state" > "$status_file"
         echo "[$ts] ${ENTITY_LABEL} #${pr_num}: SKIPPED ($state)"
         return

--- a/claude/skill-references/parallel-claude-runner-template.sh
+++ b/claude/skill-references/parallel-claude-runner-template.sh
@@ -17,6 +17,11 @@ PRS=({{PRS}})                   # space-separated PR numbers
 MODE="{{MODE}}"                 # "review" or "address"
 MODE_LABEL="{{MODE_LABEL}}"     # "Review" or "Address" (pre-capitalized for bash 3.x)
 MODEL="${MODEL:-{{MODEL}}}"     # claude model — runtime env override supported
+ENTITY_PREFIX="{{ENTITY_PREFIX}}"     # "pr" or "issue" — controls directory naming
+ENTITY_LABEL="{{ENTITY_LABEL}}"       # "PR" or "Issue" — controls log labels
+STATE_FIELD="{{STATE_FIELD}}"         # "pr_state" or "issue_state" — status.md field name
+STATE_CHECK_CMD="{{STATE_CHECK_CMD}}" # "gh pr view" or "gh issue view" — API pre-flight
+TERMINAL_STATES="{{TERMINAL_STATES}}" # "MERGED CLOSED" or "CLOSED" — pre-flight skip states
 {{#BRANCHES}}
 # Branch mapping (address mode only — function for bash 3.x compat on macOS)
 branch_for() {
@@ -83,7 +88,7 @@ echo "Started at:    $(date)"
 echo ====================================================
 echo ""
 echo "Watch progress in another terminal:"
-echo "  while clear; do for f in $RUN_DIR/pr-*/status.md; do echo \"--- \$f\"; cat \"\$f\"; echo; done; sleep 5; done"
+echo "  while clear; do for f in $RUN_DIR/${ENTITY_PREFIX}-*/status.md; do echo \"--- \$f\"; cat \"\$f\"; echo; done; sleep 5; done"
 echo ""
 
 # Clear stale rate-limit sentinel from prior runs
@@ -105,15 +110,15 @@ if [ -f "${RUN_DIR}/manifest-updates.json" ]; then
                     break
                 fi
             done
-            if [ "$already_present" = false ] && [ -f "${RUN_DIR}/pr-${item_id}/prompt.txt" ]; then
+            if [ "$already_present" = false ] && [ -f "${RUN_DIR}/${ENTITY_PREFIX}-${item_id}/prompt.txt" ]; then
                 PRS+=("$item_id")
             fi
         elif [ "$action" = "close" ] && [ -n "$item_id" ]; then
             close_reason=$(printf '%s' "$line" | jq -r '.reason // empty' 2>/dev/null)
-            mkdir -p "${RUN_DIR}/pr-${item_id}"
-            printf '# PR #%s\nmilestone: closed\nreason: %s\npr_state: %s\n' \
-                "$item_id" "${close_reason:-director-closed}" "${close_reason:-CLOSED}" \
-                > "${RUN_DIR}/pr-${item_id}/status.md"
+            mkdir -p "${RUN_DIR}/${ENTITY_PREFIX}-${item_id}"
+            printf '# %s #%s\nmilestone: closed\nreason: %s\n%s: %s\n' \
+                "$ENTITY_LABEL" "$item_id" "${close_reason:-director-closed}" "$STATE_FIELD" "${close_reason:-CLOSED}" \
+                > "${RUN_DIR}/${ENTITY_PREFIX}-${item_id}/status.md"
         fi
     done < "${RUN_DIR}/manifest-updates.json"
 fi
@@ -121,7 +126,7 @@ fi
 # --- State writer ---
 write_state() {
     local pr_num=$1 state=$2
-    local pr_dir="${RUN_DIR}/pr-${pr_num}"
+    local pr_dir="${RUN_DIR}/${ENTITY_PREFIX}-${pr_num}"
     local now
     now=$(date -Iseconds 2>/dev/null || date +%Y-%m-%dT%H:%M:%S%z)
     {
@@ -135,49 +140,56 @@ write_state() {
     } > "${pr_dir}/state.md"
 }
 
+# --- Terminal state check ---
+is_terminal_state() {
+    local state=$1
+    case " $TERMINAL_STATES " in
+        *" $state "*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 # --- Per-PR function ---
 process_pr() {
     local pr_num=$1
-    local pr_dir="${RUN_DIR}/pr-${pr_num}"
+    local pr_dir="${RUN_DIR}/${ENTITY_PREFIX}-${pr_num}"
     local log_file="${pr_dir}/output.log"
     local status_file="${pr_dir}/status.md"
     local start_time=$(date +%s)
     local ts=$(date +%H:%M:%S)
 
-    # Pre-flight: skip only on terminal PR states (MERGED/CLOSED) — not on "done".
+    # Pre-flight: skip only on terminal entity states — not on "done".
     # "done" means the *previous* cycle completed, not that there's nothing to do.
     # The session's watermark logic handles rerun detection (compares HEAD SHA +
     # comment IDs against current state). The runner only skips truly terminal cases.
-    # NOTE: Adapt `pr_state:` to match your sweep type (e.g., `issue_state:` for issue-based sweeps).
-    # Also adapt terminal state values below — MERGED/CLOSED are PR-specific; issues only have CLOSED.
     if [ -f "$status_file" ]; then
         local cached_state
-        cached_state=$(grep '^pr_state:' "$status_file" 2>/dev/null | awk '{print $2}')
-        if [ "$cached_state" = "MERGED" ] || [ "$cached_state" = "CLOSED" ]; then
-            echo "[$ts] PR #${pr_num}: SKIPPED ($cached_state, from status.md)"
+        cached_state=$(grep "^${STATE_FIELD}:" "$status_file" 2>/dev/null | awk '{print $2}')
+        if is_terminal_state "$cached_state"; then
+            echo "[$ts] ${ENTITY_LABEL} #${pr_num}: SKIPPED ($cached_state, from status.md)"
             return
         fi
     fi
 
     # Pre-flight: skip if rate-limited (after terminal check so completed sessions aren't regressed)
     if [ -f "${RUN_DIR}/.rate-limited" ]; then
-        printf '# PR #%s\nmilestone: skipped\nreason: rate-limited\n' "$pr_num" > "$status_file"
-        echo "[$ts] PR #${pr_num}: SKIPPED (rate-limited)"
+        printf '# %s #%s\nmilestone: skipped\nreason: rate-limited\n' "$ENTITY_LABEL" "$pr_num" > "$status_file"
+        echo "[$ts] ${ENTITY_LABEL} #${pr_num}: SKIPPED (rate-limited)"
         return
     fi
 
-    # Pre-flight: skip merged/closed PRs (API fallback for first run or missing status.md)
+    # Pre-flight: skip terminal entities (API fallback for first run or missing status.md)
     local state
-    state=$(gh pr view "$pr_num" --json state -q '.state' 2>/dev/null || echo "UNKNOWN")
-    if [ "$state" != "OPEN" ]; then
-        printf '# PR #%s\nmilestone: skipped\nreason: %s\npr_state: %s\n' "$pr_num" "$state" "$state" > "$status_file"
-        echo "[$ts] PR #${pr_num}: SKIPPED ($state)"
+    state=$($STATE_CHECK_CMD "$pr_num" --json state -q '.state' 2>/dev/null || echo "UNKNOWN")
+    if is_terminal_state "$state"; then
+        printf '# %s #%s\nmilestone: skipped\nreason: %s\n%s: %s\n' "$ENTITY_LABEL" "$pr_num" "$state" "$STATE_FIELD" "$state" > "$status_file"
+        echo "[$ts] ${ENTITY_LABEL} #${pr_num}: SKIPPED ($state)"
         return
     fi
 
-    echo "[$ts] PR #${pr_num}: launching claude -p session..."
-    printf '# PR #%s Status\nmilestone: launching\nstarted_at: %s\n' \
-        "$pr_num" "$(date -Iseconds)" > "$status_file"
+    echo "[$ts] ${ENTITY_LABEL} #${pr_num}: launching claude -p session..."
+    printf '# %s #%s Status\nmilestone: launching\nstarted_at: %s\n' \
+        "$ENTITY_LABEL" "$pr_num" "$(date -Iseconds)" > "$status_file"
 
     # Archive previous cycle's raw.jsonl (raw-1.jsonl, raw-2.jsonl, ...)
     if [ -f "$pr_dir/raw.jsonl" ]; then
@@ -258,7 +270,7 @@ process_pr() {
                     live_mtime=$(stat -c %Y "$live_file" 2>/dev/null || stat -f %m "$live_file" 2>/dev/null || echo "$now_epoch")
                     local idle_seconds=$((now_epoch - live_mtime))
                     if [ "$idle_seconds" -gt "$INACTIVITY_TIMEOUT_SEC" ]; then
-                        echo "[$(date +%H:%M:%S)] PR #${pr_num}: inactivity timeout (${idle_seconds}s idle, attempt ${attempt}/${MAX_ATTEMPTS})"
+                        echo "[$(date +%H:%M:%S)] ${ENTITY_LABEL} #${pr_num}: inactivity timeout (${idle_seconds}s idle, attempt ${attempt}/${MAX_ATTEMPTS})"
                         # Kill the claude session
                         if [ -f "${pr_dir}/session.pid" ]; then
                             kill "$(cat "${pr_dir}/session.pid")" 2>/dev/null || true
@@ -299,7 +311,7 @@ process_pr() {
 
         # Handle exit status — success takes priority over transient rate limits
         if [ "$exit_status" = "success" ]; then
-            echo "[$end_ts] PR #${pr_num}: DONE (${duration}s, attempt ${attempt}/${MAX_ATTEMPTS})"
+            echo "[$end_ts] ${ENTITY_LABEL} #${pr_num}: DONE (${duration}s, attempt ${attempt}/${MAX_ATTEMPTS})"
 
             # Compute context window usage from the latest assistant message's usage block.
             # cache_read + cache_creation + input_tokens = total tokens the model processed this turn,
@@ -347,7 +359,7 @@ process_pr() {
         # Rate limit detection (only on failure — transient limits during successful sessions are harmless)
         if grep -q "hit your limit" "$log_file" 2>/dev/null; then
             exit_status="rate-limited"
-            printf '# PR #%s Status\nmilestone: rate-limited\n' "$pr_num" > "$status_file"
+            printf '# %s #%s Status\nmilestone: rate-limited\n' "$ENTITY_LABEL" "$pr_num" > "$status_file"
             touch "${RUN_DIR}/.rate-limited"
             write_state "$pr_num" "rate-limited" "attempt: $attempt" "max_attempts: $MAX_ATTEMPTS"
             break
@@ -355,7 +367,7 @@ process_pr() {
 
         # Resume fallback: if session not found, switch to fresh start (don't count as an attempt)
         if [ "$use_resume" = true ] && grep -q "No conversation found" "$pr_dir/raw.jsonl" 2>/dev/null; then
-            echo "[$end_ts] PR #${pr_num}: resume session expired — falling back to fresh start"
+            echo "[$end_ts] ${ENTITY_LABEL} #${pr_num}: resume session expired — falling back to fresh start"
             rm -f "$pr_dir/session.state"
             use_resume=false
             resume_session_id=""
@@ -367,23 +379,23 @@ process_pr() {
 
         # Failure — retry or escalate
         if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
-            echo "[$end_ts] PR #${pr_num}: FAILED (${duration}s, attempt ${attempt}/${MAX_ATTEMPTS}) — retrying in 5s..."
+            echo "[$end_ts] ${ENTITY_LABEL} #${pr_num}: FAILED (${duration}s, attempt ${attempt}/${MAX_ATTEMPTS}) — retrying in 5s..."
             write_state "$pr_num" "retrying" "attempt: $attempt" "max_attempts: $MAX_ATTEMPTS" "previous_exit: $exit_status"
             sleep 5
             continue
         fi
 
         # Final attempt exhausted
-        echo "[$end_ts] PR #${pr_num}: ERRORED (${duration}s, attempt ${attempt}/${MAX_ATTEMPTS})"
-        printf '# PR #%s Status\nmilestone: errored\nerror: %s after %d attempts\n' \
-            "$pr_num" "$exit_status" "$MAX_ATTEMPTS" > "$status_file"
+        echo "[$end_ts] ${ENTITY_LABEL} #${pr_num}: ERRORED (${duration}s, attempt ${attempt}/${MAX_ATTEMPTS})"
+        printf '# %s #%s Status\nmilestone: errored\nerror: %s after %d attempts\n' \
+            "$ENTITY_LABEL" "$pr_num" "$exit_status" "$MAX_ATTEMPTS" > "$status_file"
         write_state "$pr_num" "errored" "attempt: $attempt" "max_attempts: $MAX_ATTEMPTS" "exit_reason: $exit_status" "escalation: needs-director"
         return
     done
 }
 
-export -f process_pr write_state
-export RUN_DIR INACTIVITY_TIMEOUT_SEC MAX_ATTEMPTS MODEL MODE_LABEL
+export -f process_pr write_state is_terminal_state
+export RUN_DIR INACTIVITY_TIMEOUT_SEC MAX_ATTEMPTS MODEL MODE_LABEL ENTITY_PREFIX ENTITY_LABEL STATE_FIELD STATE_CHECK_CMD TERMINAL_STATES
 
 # --- Launch ---
 printf '%s\n' "${PRS[@]}" | xargs -P "$CONCURRENCY" -I {} bash -c 'process_pr "$@"' _ {}
@@ -406,5 +418,5 @@ if [ -f "${RUN_DIR}/.rate-limited" ]; then
     echo ""
 fi
 
-echo "View results:  ls ${RUN_DIR}/pr-*/results.md"
+echo "View results:  ls ${RUN_DIR}/${ENTITY_PREFIX}-*/results.md"
 echo "Ask Claude:    Check progress on ${RUN_DIR}"

--- a/claude/skill-references/sweep-scaffold.md
+++ b/claude/skill-references/sweep-scaffold.md
@@ -128,6 +128,11 @@ chmod +x <RUN_DIR>/let-it-rip.sh
   "CONCURRENCY": "3",
   "PRS": "80 81 82",
   "TIMESTAMP": "<YYYY-MM-DD-HHMM>",
+  "ENTITY_PREFIX": "pr",
+  "ENTITY_LABEL": "PR",
+  "STATE_FIELD": "pr_state",
+  "STATE_CHECK_CMD": "gh pr view",
+  "TERMINAL_STATES": "MERGED CLOSED",
   "BRANCHES": "",
   "WORKTREES": "",
   "PROJECT_ROOT": ""
@@ -137,6 +142,8 @@ chmod +x <RUN_DIR>/let-it-rip.sh
 **`MODEL` selection — based on runner role:** orchestrator runners that delegate to subagents (e.g., `sweep:review-prs` → `git:team-review-request`) → `claude-sonnet-4-6`. Leaf runners doing actual work (reading diffs, editing files, pushing commits — e.g., `sweep:address-prs`, `sweep:work-items`) → `claude-opus-4-6`. `[1m]` variant only when context demands it.
 
 **Block conditionals:** `BRANCHES` and `WORKTREES` control `{{#BRANCHES}}...{{/BRANCHES}}` and `{{#WORKTREES}}...{{/WORKTREES}}` blocks in the template. Non-empty → block kept; empty → block stripped. Review mode sets both to empty. Address mode sets both to a truthy value (e.g., `"true"`).
+
+**Entity type keys:** `ENTITY_PREFIX` controls directory naming (`pr-<N>` vs `issue-<N>`). `ENTITY_LABEL` controls log labels. `STATE_FIELD` controls the `status.md` field name for cached state. `STATE_CHECK_CMD` controls the API pre-flight command. `TERMINAL_STATES` is a space-separated list of states that trigger pre-flight skip. Every sweep skill must provide all 5 keys — there are no defaults.
 
 **Address mode data files** (written to `<RUN_DIR>/` alongside metadata.json):
 - `branch-cases.txt` — case-statement body for `branch_for()` (e.g., `80) echo "feat/auth" ;;`)
@@ -149,8 +156,8 @@ These are included via `{@file}` references in the template. Review mode doesn't
 
 The generated script has a two-tier pre-flight before launching each session:
 
-1. **Local status.md check (free).** Read `pr_state` from the PR's existing `status.md`. If MERGED or CLOSED, skip immediately — no API call, no process overhead. This eliminates the biggest efficiency problem on rerun cycles.
-2. **API fallback (1 API call).** If no `status.md` exists or `pr_state` is not terminal, use `fetch-pr-watermark.sh` (or equivalent platform command) to check current state. This covers first runs and PRs whose state changed externally. The API fallback also writes `pr_state` to `status.md` so subsequent cycles use the local check.
+1. **Local status.md check (free).** Read `STATE_FIELD` from the entity's existing `status.md`. If the value is in `TERMINAL_STATES`, skip immediately — no API call, no process overhead. This eliminates the biggest efficiency problem on rerun cycles.
+2. **API fallback (1 API call).** If no `status.md` exists or the state field is not terminal, use `STATE_CHECK_CMD` to check current state. This covers first runs and entities whose state changed externally. The API fallback also writes the state field to `status.md` so subsequent cycles use the local check.
 
 Address mode: the same state check MUST also be included in the worktree setup loop (`setup_worktrees`), before fetching or creating worktrees.
 
@@ -161,7 +168,7 @@ Artifacts written to <RUN_DIR>/
 
   manifest.json    — <M> eligible, <K> skipped
   let-it-rip.sh    — concurrency: <CONCURRENCY>
-  pr-<N>/          — <M> PR directories with prompts
+  <ENTITY_PREFIX>-<N>/  — <M> item directories with prompts
 
 To launch:        bash <RUN_DIR>/let-it-rip.sh
 Re-run (loop):    bash <RUN_DIR>/let-it-rip.sh  (same command — sessions with no changes exit cleanly)
@@ -171,7 +178,7 @@ Retro:            "Retro on <RUN_DIR>"
 
 ## Progress Check
 
-Read all `pr-*/status.md` files, present:
+Read all `<ENTITY_PREFIX>-*/status.md` files, present:
 
 | PR | Milestone | Started |
 |----|-----------|---------|
@@ -180,7 +187,7 @@ Read all `pr-*/status.md` files, present:
 
 ## Retro
 
-Read `manifest.json`, all `pr-*/results.md`, and all `pr-*/learnings.md`. Note that `results.md` and `learnings.md` are append-only — each run adds a dated section. Show the latest round per PR plus a round count. Include: skipped PRs, aggregated learnings by theme, and summary line.
+Read `manifest.json`, all `<ENTITY_PREFIX>-*/results.md`, and all `<ENTITY_PREFIX>-*/learnings.md`. Note that `results.md` and `learnings.md` are append-only — each run adds a dated section. Show the latest round per PR plus a round count. Include: skipped PRs, aggregated learnings by theme, and summary line.
 
 ## Convergence
 

--- a/claude/skill-references/sweep-scaffold.md
+++ b/claude/skill-references/sweep-scaffold.md
@@ -126,7 +126,7 @@ chmod +x <RUN_DIR>/let-it-rip.sh
   "MODEL": "<model>",
   "RUN_DIR": "<absolute path>",
   "CONCURRENCY": "3",
-  "PRS": "80 81 82",
+  "ITEMS": "80 81 82",
   "TIMESTAMP": "<YYYY-MM-DD-HHMM>",
   "ENTITY_PREFIX": "pr",
   "ENTITY_LABEL": "PR",
@@ -148,7 +148,7 @@ chmod +x <RUN_DIR>/let-it-rip.sh
 **Address mode data files** (written to `<RUN_DIR>/` alongside metadata.json):
 - `branch-cases.txt` — case-statement body for `branch_for()` (e.g., `80) echo "feat/auth" ;;`)
 - `worktree-cases.txt` — case-statement body for `worktree_for()` (e.g., `80) echo "/path/to/wt" ;;`)
-- `new-worktree-prs.txt` — space-separated PR numbers needing new worktrees (empty if all reused)
+- `new-worktree-items.txt` — space-separated entity numbers needing new worktrees (empty if all reused)
 
 These are included via `{@file}` references in the template. Review mode doesn't need them — the block conditional strips the enclosing section.
 


### PR DESCRIPTION
## Summary

- Adds 5 new `{{KEY}}` template placeholders to `parallel-claude-runner-template.sh`: `ENTITY_PREFIX`, `ENTITY_LABEL`, `STATE_FIELD`, `STATE_CHECK_CMD`, `TERMINAL_STATES`
- Adds `is_terminal_state()` bash helper using `case` word-boundary matching — pure bash, no subprocess per-item
- Fixes the pre-flight skip bug in `sweep:work-items` where `comment_posted: true` and `pr_opened: true` (role convergence signals) were mixed into the runner's entity terminal state check, causing false skips on rerun
- All three sweep skills (`review-prs`, `address-prs`, `work-items`) now explicitly provide entity type keys in their runner metadata.json — no defaults, no manual patching

## Test plan

- [ ] Generate a `sweep:work-items` run — verify `let-it-rip.sh` has `issue-` prefixes, `issue_state:` fields, `gh issue view` check, `CLOSED`-only terminal states without manual patching
- [ ] Generate a `sweep:review-prs` run — verify `let-it-rip.sh` still has `pr-` prefixes, `pr_state:` fields, `gh pr view` check, `MERGED CLOSED` terminal states
- [ ] Run work-items runner against open issues — confirm pre-flight passes through `OPEN` issues (no `comment_posted` false-skip)
- [ ] Run review-prs runner against merged PRs — confirm pre-flight skips correctly

Relates to #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)