### PR TITLE
feat: enforce delivery structure declaration in confirmer prompt (#98)

### DIFF
--- a/claude/commands/sweep/work-items/confirmer-prompt.md
+++ b/claude/commands/sweep/work-items/confirmer-prompt.md
@@ -49,7 +49,7 @@ Read the comment thread. Identify the clarifier's questions, operator's answers,
 
 ## Step 11: Draft and Post Confirmation
 
-Post a comment with: (1) your understanding of each answer in your own words (not parroting), flagging tensions or implications; (2) a concrete implementation plan; (3) open questions only if genuine; (4) explicit ask for confirmation.
+Post a comment with: (1) your understanding of each answer in your own words (not parroting), flagging tensions or implications; (2) a concrete implementation plan — state the delivery structure before listing phases: "Single PR containing:" or "Separate PRs (N total):" with one-line scope per PR; when declaring Separate PRs, propose concrete sub-issues with titles, scopes, and dependency order; (3) open questions only if genuine; (4) explicit ask for confirmation.
 
 Write the comment body to `{ISSUE_DIR}/comment-body.md` using the Write tool, then post:
 ```bash
@@ -70,6 +70,10 @@ Comment format:
 
 ...
 
+**Delivery structure**: Single PR containing: [scope] OR Separate PRs (N total): [one line per PR scope]
+
+> When declaring Separate PRs: propose concrete sub-issues below (title, scope, dependency order).
+
 ### Proposed implementation
 
 **Phase 1: [name]**
@@ -80,7 +84,9 @@ Comment format:
 - [ ] ...
 
 ### Verification
-- [How you'll verify each phase works]
+<!-- For Single PR: one verification block for the issue -->
+<!-- For Separate PRs: one verification entry per sub-issue -->
+- [How you'll verify each change works]
 
 ### Open questions (if any)
 - [Genuine concerns only]

--- a/claude/commands/sweep/work-items/confirmer-prompt.md
+++ b/claude/commands/sweep/work-items/confirmer-prompt.md
@@ -72,7 +72,7 @@ Comment format:
 
 **Delivery structure**: Single PR containing: [scope] OR Separate PRs (N total): [one line per PR scope]
 
-> When declaring Separate PRs: propose concrete sub-issues below (title, scope, dependency order).
+<!-- When declaring Separate PRs: propose concrete sub-issues below (title, scope, dependency order). -->
 
 ### Proposed implementation
 


### PR DESCRIPTION
## Summary

- Updates Step 11 prose instruction to require delivery structure declaration ("Single PR containing:" or "Separate PRs (N total):") as a hard step before listing phases
- Adds `**Delivery structure**` line and sub-issue proposal note to the confirmation comment template
- Updates `### Verification` section with guidance to branch format on delivery structure (per-issue for single PR, per-sub-issue for separate PRs)

Relates to https://github.com/ahoym/dotfiles/issues/98

## Learnings Applied
- `claude-code/sweep-sessions.md` — "Phase Numbering Ambiguity in Confirmation Plans" directly motivated this change; "Confirmer Must Propose Sub-Issues for Independent Phases" shaped the sub-issue proposal requirement

## Verification
- Read modified Step 11 prose — confirms delivery structure is a hard requirement in the instruction text
- Read modified template — confirms delivery structure line, sub-issue note, and verification format guidance are present

---
*Co-Authored with [Claude Code](https://claude.ai/code) (claude-opus-4-6)*
