### PR TITLE
Batch import 2026-04-19: sweep infra + helpers + learnings batch

### DIFF
--- a/claude/commands/director/SKILL.md
+++ b/claude/commands/director/SKILL.md
@@ -88,7 +88,7 @@ The director is event-driven, not polling. It reads state on-demand: when a back
 
 **Triggers:**
 
-1. **Background task completes** (runner finishes). Use `bash ~/.claude/skill-references/sweep-status-summary.sh <run-dir>` to read all `state.md` + `status.md` at once (handles both `pr-*/` and `issue-*/` layouts; avoids permission-prompting raw `cat` loops). Use `sweep-results.sh <run-dir>` when `results.md` + `learnings.md` are needed. Build the unified monitoring table per the playbook's Monitoring Table Format. Then execute this checklist — every item, every time:
+1. **Background task completes** (runner finishes). Use `bash ~/.claude/skill-references/sweep-status-summary.sh <run-dir>` to read all `state.md` + `status.md` at once (handles both `pr-*/` and `issue-*/` layouts; avoids permission-prompting raw `cat` loops). Use `bash ~/.claude/skill-references/sweep-results.sh <run-dir>` when `results.md` + `learnings.md` are needed. Build the unified monitoring table per the playbook's Monitoring Table Format. Then execute this checklist — every item, every time:
 
    **a. Escalations:**
    - `state: errored` + `escalation: needs-director` → read `live.md` tail for diagnostics, investigate root cause, write directive for next launch or escalate to operator.

--- a/claude/commands/director/SKILL.md
+++ b/claude/commands/director/SKILL.md
@@ -88,7 +88,7 @@ The director is event-driven, not polling. It reads state on-demand: when a back
 
 **Triggers:**
 
-1. **Background task completes** (runner finishes). Read all `<run_dir>/*/state.md` and `<run_dir>/*/status.md`. Build the unified monitoring table per the playbook's Monitoring Table Format. Then execute this checklist — every item, every time:
+1. **Background task completes** (runner finishes). Use `bash ~/.claude/skill-references/sweep-status-summary.sh <run-dir>` to read all `state.md` + `status.md` at once (handles both `pr-*/` and `issue-*/` layouts; avoids permission-prompting raw `cat` loops). Use `sweep-results.sh <run-dir>` when `results.md` + `learnings.md` are needed. Build the unified monitoring table per the playbook's Monitoring Table Format. Then execute this checklist — every item, every time:
 
    **a. Escalations:**
    - `state: errored` + `escalation: needs-director` → read `live.md` tail for diagnostics, investigate root cause, write directive for next launch or escalate to operator.

--- a/claude/commands/git/create-request/SKILL.md
+++ b/claude/commands/git/create-request/SKILL.md
@@ -41,9 +41,21 @@ Before creating the review, verify these items are complete:
    - `git log origin/main..HEAD --oneline` - See commits to include (adjust base as needed)
    - `git diff origin/main..HEAD --stat` - See files changed
 
-3. **Check for uncommitted changes**:
-   - If there are uncommitted changes, ask the operator if they want to commit first
-   - Do not proceed with review creation if there are uncommitted changes
+3. **Handle uncommitted changes**:
+   Based on `git status` from step 2:
+
+   - **Clean working tree** → proceed to step 4.
+   - **Dirty + on base branch** — offer:
+     - (a) Create a new branch, stage all uncommitted, commit
+     - (b) Create a new branch, stage a subset (operator specifies which files), commit
+   - **Dirty + on feature branch** — offer:
+     - (a) Commit all uncommitted to the current branch
+     - (b) Commit a subset (leave the rest uncommitted)
+     - (c) Stash, proceed with only the already-committed state
+
+   **Multi-concern flag**: if the uncommitted set spans logically distinct concerns (e.g., unrelated features, docs + code, migration + cleanup), surface the grouping before the operator picks. Suggest running this skill once per concern — each iteration stages only the relevant subset — rather than bundling into one PR.
+
+   After the chosen action completes, re-check `git status` and continue to step 4 only when the tree is clean (or stashed).
 
 4. **Run verifications**:
    Run any available automated checks **before pushing**. Look for project-standard commands (in CLAUDE.md, pyproject.toml, package.json, Makefile, etc.). Common checks:

--- a/claude/commands/git/resolve-conflicts/SKILL.md
+++ b/claude/commands/git/resolve-conflicts/SKILL.md
@@ -25,7 +25,12 @@ Flags can be combined: `/resolve-conflicts --merge main`
 
 0. **Platform commands** — platform-specific commands are inlined below via `!` preprocessing. No detection needed.
 
-0.5. **Detect in-progress rebase/merge**: check `.git/rebase-merge/`, `.git/rebase-apply/`, `.git/MERGE_HEAD`. If any exist, the operation is already underway — skip steps 1-6 (args, branch detection, fetch, preview, strategy, start) and jump to step 7 to resolve the existing conflicts, then continue with step 8+. For in-progress interactive rebase with redundant upcoming commits (e.g., branch's incremental fixes already squash-merged into base — diagnose via same-title base commit with larger tree), edit `.git/rebase-merge/git-rebase-todo` to drop redundant `pick` lines before `git rebase --skip`.
+0.5. **Detect in-flight conflict state**: run `git status --porcelain` first. If any path shows `UU`, `AA`, `DU`, `UD`, `DD`, `AU`, or `UA`, you're mid-resolution — conflicts already exist from a prior `git merge`, `git rebase`, `git stash pop`, or `git cherry-pick`. In that case:
+   - **Skip steps 1–6.** Don't re-run merge/rebase orchestration. The conflict markers are already in place.
+   - Jump to step 7 with `IN_FLIGHT=true`. Finalize with the mode's native continuation: merge → `git commit`, rebase → `git rebase --continue`, stash-pop → `git stash drop` after staging (no commit needed on the in-flight op itself), cherry-pick → `git cherry-pick --continue`.
+   - For in-progress interactive rebase with redundant upcoming commits (e.g., branch's incremental fixes already squash-merged into base — diagnose via same-title base commit with larger tree), edit `.git/rebase-merge/git-rebase-todo` to drop redundant `pick` lines before `git rebase --skip`.
+
+   **Worktree CWD check**: if the target branch is checked out in another worktree, `git checkout <branch>` will fail with "already used by worktree at <path>". Run `git worktree list` and `cd` into the worktree's path before proceeding. All subsequent git commands operate on that worktree's state.
 
 1. **Parse arguments**:
    - If `$ARGUMENTS` contains `--preview`, set `PREVIEW_ONLY=true`
@@ -145,11 +150,13 @@ Flags can be combined: `/resolve-conflicts --merge main`
 
    **Resolution flow:**
    - **All conflicts in the current commit/merge are additive** → propose a single batch combine-both resolution listing each conflict as a row in a table. Single approval covers all of them. Do NOT prompt per-conflict.
-   - **Mixed or any contested** → present the table, mark additive rows as auto-combine, and ask the operator per contested row only:
-     - Keep ours (current branch in merge / base branch in rebase)
-     - Keep theirs (base branch in merge / your commit in rebase)
-     - Combine both
-     - Custom resolution
+   - **Mixed or any contested** → present the table, mark additive rows as auto-combine, and ask the operator per contested row only. "Combine both" is not a single strategy — pick the sub-strategy that matches the content:
+     - **Keep ours** (current branch in merge / base branch in rebase)
+     - **Keep theirs** (base branch in merge / your commit in rebase)
+     - **Additive union**: both sides added disjoint content (e.g., different new sections in a docs file). Concatenate both, preserve heading level conventions, de-dup any accidentally-overlapping content.
+     - **Subsumption drop**: one side is strictly weaker — narrower permission pattern, subset of the other's coverage, older naming since renamed. Drop the weaker side, keep the stronger.
+     - **Rename-aware rewrite**: one side renamed symbols/variables outside the conflict region (e.g., `pr_num → item_num`). Apply the other side's *intent* against the new names, not verbatim. Cross-check any references the stash/commit introduced.
+     - **Custom resolution**
    - **Bare rename replay** (e.g., main added `foo` + siblings; your branch has a later commit renaming `foo` → `bar`) resolves as: keep all main's additions, apply the rename to the one symbol, drop the conflict frame. Propose as a single action.
 
    Apply the resolution and stage each file:
@@ -157,7 +164,19 @@ Flags can be combined: `/resolve-conflicts --merge main`
    git add <resolved-file>
    ```
 
-8. **Complete the operation**:
+8. **Scan for symbol drift outside conflict regions** (code files only):
+
+   When one side renames symbols (variables, functions, keys) outside the conflict boundaries, git auto-merges content from the *unchanged* side that still references old names. Conflict markers don't flag this — the merged file parses but uses inconsistent names.
+
+   After staging each code file, check for renames in the commits touching it:
+   ```bash
+   git log --oneline -p origin/<base-branch>..HEAD -- <file> | grep -E '^[-+].*\b\w+\s*=' | head -20
+   ```
+   If renames exist, grep the resolved file for the old names and rewrite stragglers before finalizing. Prose-heavy files (docs, learnings) rarely need this check.
+
+9. **Complete the operation**:
+
+   **If IN_FLIGHT=true (from pre-flight):** finalize with the mode's native continuation — `git commit` for merge, `git rebase --continue` for rebase, `git stash drop` for stash-pop (no commit of the pop itself), `git cherry-pick --continue` for cherry-pick. Skip steps 11-12.
 
    **If STRATEGY=merge:**
    ```bash
@@ -168,9 +187,9 @@ Flags can be combined: `/resolve-conflicts --merge main`
    ```bash
    git rebase --continue
    ```
-   Repeat steps 7-8 for each commit with conflicts until rebase completes.
+   Repeat steps 7-9 for each commit with conflicts until rebase completes.
 
-9. **Restore stashed changes** (if `STASHED=true`):
+10. **Restore stashed changes** (if `STASHED=true`):
    ```bash
    git stash pop
    ```
@@ -201,7 +220,6 @@ Flags can be combined: `/resolve-conflicts --merge main`
     - Leave unstaged and let the operator handle it
 
     Do NOT silently amend or commit — the decision depends on project convention (squash-merge vs linear history) and the operator's preference.
-
 11. **Push to update the PR**:
 
     **If STRATEGY=merge:**
@@ -289,6 +307,8 @@ Rebase complete. Force push to update PR? → Pushed. PR #8 is now mergeable.
 
 - **Default is auto-selection** — prefers rebase for clean history, falls back to merge when it's cheaper (merge commits on branch, or rebase would re-conflict the same files across multiple commits)
 - **Use `--rebase` or `--merge`** to skip auto-selection and force a strategy
-- Always fetch the latest base branch before starting
-- Abort if needed: `git merge --abort` or `git rebase --abort`
+- **In-flight conflicts are auto-detected** — if `git status` already shows unmerged paths (from stash pop, interrupted merge/rebase, cherry-pick), the skill jumps to resolution and uses the right native continuation
+- **Worktrees**: if the target branch is checked out in another worktree, `cd` into its path first — `git checkout <branch>` fails while another worktree holds it
+- Always fetch the latest base branch before starting (skipped in in-flight mode)
+- Abort if needed: `git merge --abort` · `git rebase --abort` · `git stash pop` keeps stash, so `git checkout .` + leave stash · `git cherry-pick --abort`
 - Rebase rewrites history — requires `--force-with-lease` push

--- a/claude/commands/learnings/compound/SKILL.md
+++ b/claude/commands/learnings/compound/SKILL.md
@@ -100,12 +100,11 @@ Save new patterns and learnings from the current session into global skills, gui
      - **Skills** → `~/.claude/commands/<skill-name>/SKILL.md`
      - **Guidelines** → `~/.claude/guidelines/<guideline-name>.md`
      - **Learnings** → resolve `localPath` from the provider whose `writeScope` matches the learning's scope. Project-local learnings use `projectLocal.path` (relative to project root).
-   - **Multi-provider write:** For each **Global** learning, write to all providers with `writeScope: "global"` and `writable: true` (not just the `defaultWriteTarget`). For each additional writable provider beyond the default:
+   - **Multi-provider write:** For each **Global** learning, write to all providers with `writeScope: "global"` and `writable: true` (not just the `defaultWriteTarget`). **Early exit:** if only one `writeScope: "global"` provider exists (count providers first from `learnings-providers.json`), skip multi-write silently — don't deliberate, don't ask the operator. For each additional writable provider beyond the default:
      - Use `localPath` from the provider entry as the write target
      - **New file**: add an index entry to the provider directory's `CLAUDE.md` (format: `` - `filename.md` — one-sentence description ``)
      - **Existing file**: no index update needed unless the description is stale
      - Cross-refs in the copy must use paths relative to the provider's `localPath` (rewrite any `~/.claude/learnings/` refs)
-     - If no additional global providers exist, skip multi-write silently
 
 4. **Verify and report**:
    - Read back each written file to confirm content was saved correctly

--- a/claude/commands/sweep/address-prs/addresser-prompt.md
+++ b/claude/commands/sweep/address-prs/addresser-prompt.md
@@ -25,13 +25,23 @@ You are an autonomous addresser agent. Your job is to address review comments on
 - **Branch**: {BRANCH} → {BASE}
 - **Mode**: {MODE}
 
-## Step 5: Enter Worktree
+## Step 5: Verify Worktree CWD
 
-`cd` into the worktree directory: `{WORKTREE_PATH}`
+Your shell CWD is already `{WORKTREE_PATH}` — the runner launches this session with `cd $worktree && exec claude -p`. Run plain git commands; they operate on the PR branch because CWD is already the worktree.
 
-Verify with **separate** Bash calls (do NOT combine with `&&`):
-1. `pwd`
-2. `git branch --show-current`
+**Do NOT `cd` or use `git -C <path>`.** Both `cd <abs-path> && <cmd>` and `git -C <abs-path> <cmd>` trip Claude Code's hook-injection safety gate — no permission pattern overrides it, and headless `claude -p` sessions cannot approve manual prompts. This specifically breaks `git:resolve-conflicts` and any other skill that needs to run git on the PR branch.
+
+Verify CWD with a single tool call (no compound):
+```bash
+pwd
+```
+
+Expected output: `{WORKTREE_PATH}`. If `pwd` reports a different path, the runner was invoked without the CWD-setting fix — update `{PR_DIR}/status.md` milestone to `errored` (reason: `runner cwd fix missing — see parallel-claude-runner-template.sh`) and exit.
+
+Then in a separate tool call, confirm the branch:
+```bash
+git branch --show-current
+```
 
 ## Step 6: Conflict Check
 

--- a/claude/commands/sweep/compound-agent-learnings/SKILL.md
+++ b/claude/commands/sweep/compound-agent-learnings/SKILL.md
@@ -15,6 +15,16 @@ Per-item `learnings.md` files in `tmp/claude-artifacts/sweep-*/` contain agent o
 - Director Phase 5 wrap-up, after all sessions reach terminal state
 - Manually, to retroactively extract from prior run dirs
 
+## Prerequisites
+
+For prompt-free execution, ensure these allow patterns in `~/.claude/settings.json`:
+
+```json
+"Read(tmp/claude-artifacts/**)",
+"Edit(~/.claude/learnings/**)",
+"Write(~/.claude/learnings/**)"
+```
+
 ## Steps
 
 1. **Find files.** Glob `<RUN_DIR>/{issue,pr}-*/learnings.md`. None → exit "No agent learnings found."

--- a/claude/commands/sweep/compound-agent-learnings/SKILL.md
+++ b/claude/commands/sweep/compound-agent-learnings/SKILL.md
@@ -1,0 +1,53 @@
+---
+description: "Promote per-agent learnings.md observations from a sweep run into the global learnings system. Bridges the gap between per-issue/per-PR learnings written by claude -p sessions and ~/.claude/learnings/."
+---
+
+# Compound Agent Learnings
+
+Per-item `learnings.md` files in `tmp/claude-artifacts/sweep-*/` contain agent observations that otherwise never reach the global learnings system. This skill extracts, classifies, and promotes the generalizable ones.
+
+## Usage
+
+- `/sweep:compound-agent-learnings <RUN_DIR>` — process a single sweep run
+
+## When to Run
+
+- Director Phase 5 wrap-up, after all sessions reach terminal state
+- Manually, to retroactively extract from prior run dirs
+
+## Steps
+
+1. **Find files.** Glob `<RUN_DIR>/{issue,pr}-*/learnings.md`. None → exit "No agent learnings found."
+
+2. **Extract observations** from each file's most recent dated section. Skip "Learnings loaded:" / "provenance" blocks. Capture "Observations:" / "New observations:" blocks only.
+
+3. **Classify each:**
+   - **Project-local:** references specific paths/functions/modules; already-fixed bugs (live in PR description)
+   - **Generalizable:** pattern statements, language/framework gotchas, testing patterns, refactoring patterns
+
+4. **Triage table:**
+
+   | # | Source | Observation | Class | Target |
+   |---|--------|-------------|-------|--------|
+   | 1 | issue-97 | Found 2 doc hits beyond plan | Local | (skip) |
+   | 2 | issue-98 | sleep patch moves with code | Global | refactoring-patterns.md |
+   | 3 | issue-99 | conftest sys.modules pre-mock unblocks __init__.py singletons | Global | python-specific.md |
+
+5. **Verify non-obvious claims before promoting.** Agent observations mix facts ("I couldn't run X") with theories ("X happens because Y"). Facts compound verbatim; theories need verification. If the suggested learning encodes a *theory* about platform/framework behavior — test it (run the command, read the source, check the file) before promoting. A plausible-but-wrong theory compounded becomes a load-bearing lie.
+
+6. **Promote generalizables.** Write directly to the suggested file using the conciseness gate from `/learnings:compound` (lead with rule, one-to-two sentences, no hedging). Direct write is fine for already-classified items — invoking `/learnings:compound` adds overhead.
+
+7. **Report:** what was promoted where, what was skipped, what was flagged for verification but couldn't be verified (left in tmp/).
+
+## Important Notes
+
+- Project-local observations stay in `tmp/` — already in the right place.
+- Run BEFORE the operator-facing `/learnings:compound` so duplicates dedupe in that pass.
+- Per-item `learnings.md` is append-only — one run after final convergence sees all dated sections.
+- **Observation vs theory:** an agent saying "tests didn't run" is a fact; their explanation of *why* may be wrong. Promote the fact, verify the theory.
+
+## Cross-Refs
+
+- `~/.claude/commands/learnings/compound/SKILL.md` — operator-facing compound skill (complementary)
+- `~/.claude/learnings/claude-code/sweep-sessions.md` — sweep session patterns
+- `~/.claude/learnings/claude-code/multi-agent/director-work-items.md` — when to invoke from director Phase 5

--- a/claude/commands/sweep/work-items/SKILL.md
+++ b/claude/commands/sweep/work-items/SKILL.md
@@ -68,7 +68,9 @@ If missing, report with `BLOCKED:` prefix listing each missing pattern. Do not c
 
 ## Reference Files
 
-- `~/.claude/skill-references/parallel-claude-runner-template.sh` — Bash template for let-it-rip.sh generation
+- `~/.claude/skill-references/work-items-generate-runner.sh` — **Recommended entrypoint.** One bash call: assembles preflight + body/comments + per-issue prompts + runner. Inputs: `manifest.json`, `metadata.json`, `repo-summary.txt`, per-issue `metadata.json`. Auto-extracts `IMPLEMENT_ISSUES` from manifest and computes `PROJECT_ROOT`.
+- `~/.claude/skill-references/work-items-runner-template.sh` — Work-items-specific runner template (issue-<N>/ dirs, `gh issue view`, `IMPLEMENT_ISSUES` array, conditional worktree setup, per-issue cwd). Used by work-items-generate-runner.sh.
+- `~/.claude/skill-references/parallel-claude-runner-template.sh` — Generic PR-centric template (used by `sweep:address-prs` / `sweep:review-prs`). Do NOT use directly for work-items — it lacks issue semantics + worktree-from-main setup.
 - `~/.claude/skill-references/fill-template.sh` — Bash assembly for prompt generation (replaces LLM string substitution)
 - @~/.claude/skill-references/sweep-scaffold.md — Shared artifact structure, watermark logic, result/learnings patterns, **progress-check script**
 - `~/.claude/skill-references/sweep-agent-preflight.md` — Shared preflight steps (1-5 + Work Item + Repo Context) for all agent prompts

--- a/claude/guidelines/context-aware-learnings.md
+++ b/claude/guidelines/context-aware-learnings.md
@@ -19,6 +19,9 @@ All gates are mandatory when their trigger fires. No exceptions.
 | **Keyword** | Domain keyword or quoted term in user message | Glob filenames → unloaded matches. Quoted terms bypass dedup. | No |
 | **Domain shift** | User message introduces new domain | Glob filenames → new domain keywords | No |
 | **Pre-edit check** | First Edit/Write in unloaded tech domain | Glob filenames → file's tech domain | No |
+| **Skill-task start** | Before executing a complex/long-running skill (sweeps, multi-agent, refactors) | Glob filenames → skill's domain terms (e.g., `sweep`, `director`, `compound`, `worktree`, `multi-agent`) | No |
+
+**Skill-task gate rationale:** Other gates fire on the user's domain, not the skill's operational domain. Multi-agent / sweep / refactor skills have their own learnings clusters that go unloaded when the user message doesn't name them. Load operational learnings before the skill's first substantive action.
 
 **Dedup**: don't re-load files already read this session. When context compression makes history uncertain, err toward re-checking.
 

--- a/claude/learnings/bash-patterns.md
+++ b/claude/learnings/bash-patterns.md
@@ -405,6 +405,23 @@ wt=$(setup)
 
 For one-off JSON validation, data munging, or arithmetic, reach for `jq`, `node -e`, or shell builtins/coreutils before `python3 -c '...'`. Python invocations require their own permission patterns and add friction; lightweight alternatives are domain-appropriate and usually already allowlisted. Pick the tool by domain: `jq` for JSON, `node -e` / `bun` for JS, `awk`/`grep`/`sed` for text. Only reach for Python when no lightweight alternative fits.
 
+## `xargs -I {} bash -c` Subshell Scoping
+
+Exported bash arrays don't propagate into `xargs -I {} bash -c '...'` subshells; only scalar exports survive. Pass list membership via an exported space-joined string + `case`:
+
+```bash
+export FOO_STR="${FOO[*]}"
+is_member() {
+    case " ${FOO_STR:-} " in
+        *" $1 "*) return 0 ;;
+        *)        return 1 ;;
+    esac
+}
+export -f is_member
+```
+
+`export FOO` for arrays does nothing in the child; `declare -p FOO` in the subshell shows nothing.
+
 ## Cross-Refs
 
 - `~/.claude/learnings/claude-code/platform-permissions.md` — Bash permission prefix matching gotchas (chaining, subshells, quoted strings, tilde expansion — complementary permission-system angle)

--- a/claude/learnings/bash-patterns.md
+++ b/claude/learnings/bash-patterns.md
@@ -422,6 +422,22 @@ export -f is_member
 
 `export FOO` for arrays does nothing in the child; `declare -p FOO` in the subshell shows nothing.
 
+## `xargs -I {} bash -c` Silently Drops Non-Exported Functions
+
+Functions called inside the `xargs -I {} bash -c '...'` subshell must be listed in `export -f` — otherwise the subshell gets "command not found" and the unset stdout makes failure look like empty output, not an error. Typical symptom: a script that dispatches work via `xargs -P` has a runner function that calls `worktree_for "$pr_num"`; the case-statement returns empty, downstream logic silently takes the "no worktree" branch, work runs in the wrong CWD.
+
+```bash
+# Broken: worktree_for defined but not exported
+worktree_for() { case "$1" in 104) echo "/path" ;; esac; }
+export -f process_pr                     # worktree_for missing
+printf '%s\n' "${PRS[@]}" | xargs -P 3 -I {} bash -c 'process_pr "$@"' _ {}
+
+# Fix
+export -f process_pr worktree_for branch_for
+```
+
+Always audit `export -f` against the complete function call graph reachable from the dispatched function, not just the entry point.
+
 ## Cross-Refs
 
 - `~/.claude/learnings/claude-code/platform-permissions.md` — Bash permission prefix matching gotchas (chaining, subshells, quoted strings, tilde expansion — complementary permission-system angle)

--- a/claude/learnings/cicd/gitlab.md
+++ b/claude/learnings/cicd/gitlab.md
@@ -198,6 +198,14 @@ glab api projects/:id/issues -X POST -f title=Consolidate\ Config\ Pattern
 glab api projects/:id/issues -X POST -f 'title=Consolidate Config Pattern'
 ```
 
+## glab state values are lowercase GitLab raw values
+
+`glab mr view <N> --json state` returns `opened`/`merged`/`closed` — not `OPEN`/`MERGED`/`CLOSED` like `gh`. Any cross-platform code comparing state strings needs a normalization layer (e.g., `state=$(echo "$raw" | tr '[:lower:]' '[:upper:]')`). Silent skip bugs otherwise: a `[ "$state" = "OPEN" ]` check against GitLab will always be false and skip every open MR.
+
+## glab `-F` flag semantics differ by subcommand
+
+`glab api -F key=value` is a form-field flag (curl-style). On `glab mr view`, `-F` is **not** defined as the output-format flag (`--output` is) — using it produces unexpected/undefined behavior. Don't assume `-F` is portable across glab subcommands; read `glab <sub> --help` per subcommand.
+
 ## Cross-Refs
 
 None — intra-cluster refs handled by cluster index.

--- a/claude/learnings/claude-authoring/skill-design.md
+++ b/claude/learnings/claude-authoring/skill-design.md
@@ -319,6 +319,35 @@ When a SKILL says "do NOT read X" + lists adaptations X needs (e.g., directory n
 
 **Design rule:** "Do NOT read X" next to "but X doesn't do Y/Z" is drift. Resolve by making X do Y/Z, or by removing the "Do NOT" so agents can read and adapt.
 
+## Loud-Failure Safety Net for CWD-Scoped Prompts
+
+Prompts that depend on a specific CWD (worktree-scoped sessions, project-root-scoped runners) should verify via `pwd` at an early step and `exit errored` on mismatch. Loud failure beats silent wrong-CWD corruption — a session that does the wrong thing in the wrong directory can produce convincing-but-invalid output.
+
+```markdown
+## Step 5: Verify CWD
+
+Your shell CWD is already `{WORKTREE_PATH}`. Verify:
+`​``bash
+pwd
+`​``
+
+If `pwd` reports a different path, update `status.md` milestone to `errored` (reason: `launcher CWD fix missing`) and exit.
+```
+
+Validated in practice: when the runner's `cd` fix silently broke (non-exported function, see bash-patterns.md), the safety net caught the CWD mismatch and exited cleanly instead of corrupting the working tree. Worth the two extra tool calls.
+
+## Directive Override vs Template-Encoded Boolean
+
+When a prompt template encodes a boolean flag at generation time (e.g., `RESOLVE_CONFLICTS="false"` substituted into a `{RESOLVE_CONFLICTS}` placeholder), a later director-written directive that says "do X anyway" only works if the directive is an explicit action instruction, not a flag flip. The template's conditional Step already read the stale boolean — the directive can't retroactively change it.
+
+Two patterns that work:
+- **Explicit-action directive**: "Invoke `/git:resolve-conflicts main` before Step N." The agent acts on the directive text regardless of the template conditional.
+- **Regenerate metadata + prompt**: flip the flag in `metadata.json`, re-run `fill-template.sh` to produce a new `prompt.txt`, then relaunch.
+
+The regeneration path is more reliable because it keeps template semantics consistent. The directive path is faster but only works when the skill/template supports "override by action" (not all do).
+
 ## Cross-Refs
 
 - `~/.claude/learnings/claude-code/multi-agent/orchestration.md` — agent-to-agent collaboration architecture (review cycles, auto-implementation patterns migrated from here)
+- `~/.claude/learnings/claude-code/multi-agent/headless-nesting.md` — launcher CWD pattern the safety net guards against
+- `~/.claude/learnings/bash-patterns.md` — `xargs` + `export -f` gap that motivated the safety net

--- a/claude/learnings/claude-authoring/skill-design.md
+++ b/claude/learnings/claude-authoring/skill-design.md
@@ -313,6 +313,12 @@ When a skill has downstream consumers — synthesis phases that grep for section
 
 **Rule:** before restructuring a skill's output format, grep the skill (and any subskills under the same directory) for the section names. Preserve referenced headings; reorganize only the bodies. If a heading rename is genuinely needed, update the consumer in the same edit.
 
+## SKILL Spec / Runtime Drift Is a Bug
+
+When a SKILL says "do NOT read X" + lists adaptations X needs (e.g., directory naming, mode-specific cases), the adaptations either belong **in X** (so the spec doesn't lie) OR the SKILL needs an explicit step that runs them (post-template patch, dedicated alternate template).
+
+**Design rule:** "Do NOT read X" next to "but X doesn't do Y/Z" is drift. Resolve by making X do Y/Z, or by removing the "Do NOT" so agents can read and adapt.
+
 ## Cross-Refs
 
 - `~/.claude/learnings/claude-code/multi-agent/orchestration.md` — agent-to-agent collaboration architecture (review cycles, auto-implementation patterns migrated from here)

--- a/claude/learnings/claude-authoring/skill-lifecycle.md
+++ b/claude/learnings/claude-authoring/skill-lifecycle.md
@@ -36,6 +36,10 @@ When a skill produces structured output intended for another workflow (e.g., cur
 
 When changing a contract between two skills (e.g., the parallel plan format consumed by `/parallel-plan:execute` and produced by `/parallel-plan:make`), update both skills in the same commit. A broken intermediate state — where the producer writes a new format but the consumer still expects the old one — causes silent failures. Add legacy support in the consumer if backwards compatibility is needed.
 
+### New helper scripts must be linked from the playbooks/scaffolds that document their domain
+
+Dropping a script in `~/.claude/skill-references/` (e.g., `sweep-status-summary.sh`) is half the work. Discovery is the other half: agents reading `director-playbook.md`, `sweep-scaffold.md`, or the calling SKILL.md won't find the script unless one of those docs names it. When adding a helper, grep the playbooks/scaffolds for the domain it operates on (`status.md`, `live.md`, `rate-limited`, etc.) and add a one-line reference at the first instructional point for that domain. Without this, agents fall back to raw `cat`/`for` loops that trigger permission prompts.
+
 ## Skill-Scoped Hooks: Placement Decision Framework
 
 Hooks can live in skill `hooks:` frontmatter (active only during skill execution) or in `settings.json` (active always). Choose placement based on scope:

--- a/claude/learnings/claude-code/multi-agent/CLAUDE.md
+++ b/claude/learnings/claude-code/multi-agent/CLAUDE.md
@@ -4,6 +4,7 @@ Multi-agent patterns for Claude Code — orchestration, coordination, quality, p
 |------|-------------|
 | orchestration.md | Work distribution, synthesis, parallelization, context compaction |
 | director/CLAUDE.md | Director-layer sub-cluster: observability, runner-design, watermarks-and-skip, failure-modes, process-and-meta (5 focused files; split from former director-patterns.md) |
+| director-work-items.md | Director patterns specific to `sweep:work-items` (lifecycle, per-role convergence, mixed-mode runs, stacked deps) |
 | coordination.md | Worktree commit/merge, staging, sandbox workarounds, file coordination |
 | quality.md | Verification, trust arc, agent-to-agent review, prompt design |
 | parallel-plans.md | Parallel plan execution, DAG shape, speedup bounds |

--- a/claude/learnings/claude-code/multi-agent/coordination.md
+++ b/claude/learnings/claude-code/multi-agent/coordination.md
@@ -180,7 +180,18 @@ cat prompt | (cd "$wt" && mise exec -- claude -p ...) # yarn works
 
 Only wrap with `mise exec` when `mise.toml` exists in the worktree — repos without mise don't need it.
 
+## Worktree-List TOCTOU Between Assessment and Launch
+
+`git worktree list` captured at assessment time may not match launch time — worktrees can be created or removed externally between phases. Sweep manifests that record `worktree_reused` + absolute paths at assessment can point at nonexistent directories by the time the runner executes. Symptom: runner's `git worktree add` fails with "already used by worktree at <other-path>" because a worktree was created elsewhere between assessment and launch.
+
+Mitigations:
+- Re-check `git worktree list` in the runner's `setup_worktrees` before creating new ones
+- Fall back to reusing any existing worktree for the target branch (search all paths, not just the expected one)
+- Make the assessment-time `worktree` path a hint, not a contract — runner treats it as "try this, else discover"
+
+Related to TOCTOU in orchestration pre-filters (director/failure-modes.md).
+
 ## Cross-Refs
 
 - `~/.claude/skill-references/subagent-patterns.md` — universal subagent patterns (output verification, intermediate files, structured templates)
-- `~/.claude/learnings/claude-code/multi-agent/director-patterns.md` — director-layer patterns (watermark rerun, directives, convergence rules)
+- `~/.claude/learnings/claude-code/multi-agent/director/failure-modes.md` — director failure modes including TOCTOU in orchestration pre-filters

--- a/claude/learnings/claude-code/multi-agent/director-work-items.md
+++ b/claude/learnings/claude-code/multi-agent/director-work-items.md
@@ -1,0 +1,55 @@
+Director patterns specific to orchestrating `sweep:work-items`. Lazy-loaded — read when running `/director` for work-items mode.
+- **Keywords:** director, work-items, sweep, clarify, confirm, implement, worktree, role transition, convergence per role, monitoring table, BASE_BRANCH, IMPLEMENT_ISSUES
+- **Related:** ~/.claude/learnings/claude-code/multi-agent/director/CLAUDE.md, ~/.claude/learnings/claude-code/sweep-sessions.md
+
+---
+
+# Work-Items Director Patterns
+
+## Lifecycle: clarify → confirm → implement
+
+Every issue starts at `clarify`. Implementation requires passing through `confirm` — no exceptions.
+
+| Round outcome | Operator action | Next role |
+|---------------|-----------------|-----------|
+| Sweeper posted clarifying questions | Operator answers | `clarify-confirm` (restate understanding + plan) |
+| Sweeper-Confirm posted plan | "implement" / "LGTM" | `implement` |
+| Sweeper-Confirm posted plan | Asks for re-elaboration | `clarify-confirm` (another pass) |
+| Sweeper-Confirm posted plan | Partial answer + "implement with this in mind" | `implement` (agent absorbs answer) |
+
+**Confirm → implement decision rule:** all three of (a) specific file targets, (b) expected behavior change, (c) verification method present → implement. Any missing → another clarify-confirm.
+
+## Convergence per role
+
+| Role | Converged when |
+|------|----------------|
+| Clarifier | `comment_posted: true` |
+| Confirmer | `confirmation_posted: true` |
+| Implementer | `pr_opened: true` |
+
+`milestone: errored` is NOT converged — director may write retry directives. Single-pass default: rerun only if issue updated since last pass.
+
+## Monitoring table
+
+| Issue | Role | State | Milestone | Worker | Worktree | PR |
+|-------|------|-------|-----------|--------|----------|-----|
+| #97 | implement | running | running | claude-opus-4-6 | worktrees/issue-97 | (pending) |
+| #102 | clarify-confirm | completed | done | claude-sonnet-4-6 | -- | -- |
+
+## Mixed-mode runs (clarify-confirm + implement)
+
+Mixed runs use opus globally. `work-items-runner-template.sh` sets up worktrees only for `IMPLEMENT_ISSUES` — confirmers run from project root, implementers from per-issue worktree.
+
+Tradeoff: mixed runs pay opus rate for everyone. Many confirmers + few implementers → split into two runners (sonnet confirms + opus implements). Few of each → single runner wins on simplicity.
+
+## BASE_BRANCH and stacked dependencies
+
+Each issue's metadata.json carries `BASE_BRANCH`:
+- `main` → fresh worktree, PR targets main
+- Dependency PR's branch (e.g., `sweep/97-tda-rename`) → worktree stacked on that branch, PR targets it (stacked PR)
+
+**Diamond dependency:** multiple blockers with open PRs on different branches → assessment falls back to `main` and flags `⚠️ diamond dependency`. Operator should merge one blocker before stacking the dependent.
+
+## Wrap-up: invoke `/sweep:compound-agent-learnings`
+
+Before final summary, run `/sweep:compound-agent-learnings <RUN_DIR>` — without it, agent observations die in `tmp/`.

--- a/claude/learnings/claude-code/multi-agent/headless-nesting.md
+++ b/claude/learnings/claude-code/multi-agent/headless-nesting.md
@@ -47,6 +47,18 @@ Default `claude -p` turn limit is 100. Compound Director sessions (assessment + 
 
 `/skill-name` syntax doesn't resolve in `claude -p` — use `Skill` tool calls instead. Skills designed for both interactive and headless invocation should default to `Skill("skill-name")` and only use slash-command syntax when interactive context is guaranteed. Applies to any skill an orchestrator might invoke.
 
+## Launcher Must Set CWD Before `exec claude -p`
+
+Headless sessions inherit CWD from the shell that spawned them. `sh -c "exec claude -p ..."` alone starts the session in the parent's CWD (typically the repo root). Launchers that need the session to operate on a specific directory (e.g., a per-PR worktree) must `cd` first:
+
+```bash
+| sh -c "cd \"$worktree\" && exec claude -p --model $MODEL --verbose --output-format stream-json"
+```
+
+Verified: the session's `system/init` event reports the post-`cd` CWD. Without this, agents in the wrong directory either fail or improvise (e.g., `git worktree remove` + `gh pr checkout` to move the PR branch into the parent CWD), destroying worktree state.
+
+The agent cannot self-correct via `cd <abs-path> && <cmd>` or `git -C <abs-path> <cmd>` because Claude Code's hook-injection gate blocks both in headless sessions (see platform-permissions.md).
+
 ## Cross-Refs
 
-No cross-cluster references.
+- `~/.claude/learnings/claude-code/platform-permissions.md` — hook-injection gate for `cd <path> && cmd` and `git -C <path>`

--- a/claude/learnings/claude-code/multi-agent/orchestration.md
+++ b/claude/learnings/claude-code/multi-agent/orchestration.md
@@ -258,6 +258,17 @@ When a skill spawns agents inline (via the Agent tool, waiting for results in wa
 3. **Adapt the runner.** The `parallel-claude-runner-template.sh` is PR-centric. For non-PR items (issues, tickets), adapt: directory naming (`issue-<N>`), state checks (issue open/closed vs PR merged), conditional worktrees (only for roles that modify code).
 4. **Define convergence per role.** Different roles converge differently (implementer: PR opened; clarifier: comment posted; reviewer: review posted). Document in the skill's Convergence section for directors.
 
+## Prompt Injection via Issue/Comment Body Is Architecturally Inherent to Sweep Orchestration
+
+Any sweep that fetches issue or PR body content and pipes it through `fill-template.sh` → `claude -p` has a prompt injection surface. A crafted body containing template delimiters (`{{KEY}}`), shell metacharacters, or prompt-overriding instructions can hijack the generated prompt. This is not a bug in any specific skill — it's inherent to the pattern of "fetch untrusted text → interpolate into agent prompt."
+
+Trust boundary options:
+- **Operator-authored issues (typical)**: acceptable risk; operator is implicitly trusting their own inputs
+- **Public repos or external contributors**: requires sanitization — escape template delimiters, strip control chars, or pass content as a file reference rather than inline interpolation
+- **Dependency (e.g., `fill-template.sh`'s expansion semantics)**: the template engine's security model assumes all input is trusted; agents invoking it should document that assumption
+
+Not listed as a per-skill finding because any sweep skill inherits it. Worth surfacing to the operator explicitly when setting up a sweep against anything other than operator-authored content.
+
 ## Cross-Refs
 
 - `~/.claude/learnings/claude-authoring/skill-design.md` — skill design patterns including structured footnote usage and review skill design (source of migrated agent-to-agent review patterns)

--- a/claude/learnings/claude-code/platform-permissions.md
+++ b/claude/learnings/claude-code/platform-permissions.md
@@ -190,7 +190,14 @@ Sweep and director skills sometimes rename directories within `tmp/claude-artifa
 
 ## Bash Loops and Pipes Trigger Permission Prompts
 
-`for` loops, `cat` in Bash, and piped commands don't match single-command permission patterns like `Bash(gh pr view:*)`. Use individual parallel tool calls (each matches the pattern independently) or write a script to `tmp/` and run via `bash tmp/...` which matches `Bash(bash tmp/claude-artifacts/**)`.
+`for` loops, `cat` in Bash, and piped commands don't match single-command permission patterns like `Bash(gh pr view:*)`. Use individual parallel tool calls (each matches the pattern independently) or wrap in a script under an auto-allowed path:
+
+| Path | Auto-allowed pattern | Use for |
+|------|---------------------|---------|
+| `tmp/claude-artifacts/<name>.sh` | `Bash(bash tmp/claude-artifacts/**)` | One-off session scripts (cleaned up later) |
+| `~/.claude/skill-references/<name>.sh` | `Bash(bash ~/.claude/skill-references/**)` | Reusable scripts across sessions/projects |
+
+Skill-references scripts compound — invest one session writing them, every future session benefits. Examples: `permission-analyzer.sh`, `sweep-status-summary.sh`, `gh-issues-fetch-state.sh`, `work-items-generate-runner.sh`.
 
 ## Root-Level Files Inaccessible to `claude -p` Sessions
 

--- a/claude/learnings/claude-code/platform-permissions.md
+++ b/claude/learnings/claude-code/platform-permissions.md
@@ -228,6 +228,14 @@ For Terraform specifically: bake `prevent_destroy` into modules for irreplaceabl
 
 `Skill(git:address-request-comments *)` with wildcard requires args in the permission match string. In `claude -p` sessions, `Skill("git:address-request-comments", "24")` may not match the `*` pattern — the tool invocation format passes args separately from the skill name. Adding `Skill(git:address-request-comments)` (no wildcard) alongside the `*` variant fixed the denial. Apply to all skills invoked from `claude -p`: `Skill(name)` + `Skill(name *)`.
 
+## Hook-Injection Gate Blocks `cd <abs-path> && <cmd>` and `git -C <abs-path> <cmd>` in Headless Sessions
+
+Claude Code treats both `cd <abs-path> && <cmd>` and `git -C <abs-path> <cmd>` as potential hook-injection vectors ("executes hooks from the target directory") and requires operator approval. **No permission pattern overrides this** — it's a platform-level gate, not a permission-matching decision. Headless `claude -p` sessions cannot approve manual prompts, so these patterns fail outright.
+
+Implication: any workflow that needs a headless session to operate on a specific directory must have CWD pre-set by the launcher (see `headless-nesting.md` → "Launcher Must Set CWD"). The session cannot `cd` itself in, and cannot use `git -C` to target a different path. Plain `git <cmd>` in the already-set CWD is the only reliable path.
+
+Interactive sessions hit the same gate but can approve — so workflows tested interactively may silently break when moved to `claude -p`.
+
 ## Cross-Refs
 
-No cross-cluster references.
+- `~/.claude/learnings/claude-code/multi-agent/headless-nesting.md` — launcher CWD pattern that compensates for this gate

--- a/claude/learnings/claude-code/sweep-sessions.md
+++ b/claude/learnings/claude-code/sweep-sessions.md
@@ -354,3 +354,31 @@ Claude Code's bare-repository-attack guard blocks `cd /path && git command` as a
 ## Director Must Maintain `director-state.md` Per Playbook
 
 Skipping `director-state.md` updates between cycles causes cumulative count errors (live.md grep across cycles) and prevents cross-session handoff. Write `cycle`, `review_cycles`, `address_cycles`, convergence state, and the current monitoring table snapshot after each phase transition. The state file is the director's ground truth — without it, convergence assessment relies on ad-hoc live.md parsing.
+
+## work-items Implementer Worktree Setup Pattern
+
+Implementer prompt's Step 14 does `git branch -m sweep/<N>-<slug>` — it RENAMES the current branch. Runner only needs to provide a worktree on a placeholder branch; agent derives the slug from the issue title and renames.
+
+Pattern (`~/.claude/skill-references/work-items-runner-template.sh`):
+- Runner creates worktree at `<RUN_DIR>/worktrees/issue-<N>` on placeholder `sweep/<N>-impl` from `BASE_BRANCH` (read from issue's metadata.json).
+- Per-issue launch: `sh -c "cd '$worktree' && exec claude -p ..."` — each parallel session runs in its own worktree.
+- Worktrees preserved across runs; operator removes manually with `git worktree remove`.
+- For non-default base branches (stacked deps): `git fetch origin <BASE_BRANCH>` first.
+
+## Worktree `claude -p` Settings: Committed vs Gitignored
+
+A worktree session sees the settings files that exist in its checkout. Boundary is **committed vs gitignored**, not project vs global:
+
+| File | Visible in worktree |
+|------|---------------------|
+| `~/.claude/settings.json` | Yes |
+| `.claude/settings.json` (committed) | Yes |
+| `.claude/settings.local.json` (gitignored) | No |
+
+Implementer test/lint patterns (`uv run pytest`, `npm test`, etc.) must live in `~/.claude/settings.json` or **committed** `.claude/settings.json` — `settings.local.json` won't propagate.
+
+## Default to Operator-Greenlit Scope; Don't Narrow Silently
+
+When the operator approves a scope (N items, full task), default to executing the full scope. If you have reason to narrow, name it explicitly ("I'd rather validate against 2 first because X") so they can accept or override.
+
+Silent narrowing forces the operator to detect what's missing. Even when narrowing is the right call, name the reason inline.

--- a/claude/learnings/claude-code/sweep-sessions.md
+++ b/claude/learnings/claude-code/sweep-sessions.md
@@ -382,3 +382,7 @@ Implementer test/lint patterns (`uv run pytest`, `npm test`, etc.) must live in 
 When the operator approves a scope (N items, full task), default to executing the full scope. If you have reason to narrow, name it explicitly ("I'd rather validate against 2 first because X") so they can accept or override.
 
 Silent narrowing forces the operator to detect what's missing. Even when narrowing is the right call, name the reason inline.
+
+## Director Should Run `/sweep:compound-agent-learnings` Before Wrap-Up
+
+Per-issue `learnings.md` files written by `claude -p` agents die in `tmp/` unless promoted. Director Phase 5 (wrap-up) should invoke `/sweep:compound-agent-learnings <RUN_DIR>` to extract generalizable observations and route them through `/learnings:compound`. This applies to all sweep skills (work-items, address-prs, review-prs).

--- a/claude/learnings/git-github-api.md
+++ b/claude/learnings/git-github-api.md
@@ -196,6 +196,18 @@ glab api projects/:id/merge_requests/<IID> -X PUT \
 
 `gh api repos/{owner}/{repo}/pulls/<N>/reviews --input <payload>` with `"event": "APPROVE"` returns HTTP 422 `"Can not approve your own pull request"` when the authenticated user owns the PR. Fall back to `"event": "COMMENT"` with an explicit "ready to merge" signal in the body. Detect ownership before posting to avoid the round-trip.
 
+## Inline Comment Reply Endpoint Requires Pull Number
+
+GitHub's REST endpoint for replying to an inline review comment is `POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies`. The shorter `/repos/{owner}/{repo}/pulls/comments/{comment_id}/replies` (without `{pull_number}`) returns 404. The pull number is redundant given the comment ID uniquely identifies the thread, but the API requires it anyway.
+
+```bash
+# Correct
+gh api repos/owner/repo/pulls/123/comments/456789/replies -X POST -f body="..."
+
+# 404
+gh api repos/owner/repo/pulls/comments/456789/replies -X POST -f body="..."
+```
+
 ## Cross-Refs
 
 - `~/.claude/learnings/git-patterns.md` — core git operations, rebase, merge, worktree, commit hygiene

--- a/claude/learnings/git-patterns.md
+++ b/claude/learnings/git-patterns.md
@@ -312,6 +312,28 @@ The system prompt's `gitStatus` block is a snapshot from session start and does 
 ## Co-Locate Cross-Ref Doc Updates With Their Targets
 
 When a skill/doc adds links to files being modified in another in-progress change, ship both in the same PR. Splitting them means the cross-refs point at files that either don't exist yet (new) or have stale content until the target PR lands. Applies to: skill "Related Learnings" sections, CLAUDE.md index entries, any `~/.claude/learnings/...` reference.
+## Hunk Splitting Across Commits Without `git add -p`
+
+Agent workflows can't drive interactive `git add -p`. Split one file across N sequential commits by editing the working tree to each commit's subset:
+
+1. Save full modified file to `/tmp/<name>.md`.
+2. Revert hunks belonging to later commits; stage + commit the first subset.
+3. For each next commit: add the next subset's hunks back; stage + commit.
+4. Final commit: copy the saved full version back.
+
+Order commits additively so each step only adds lines — simpler than shrinking and re-growing. Skip the save/restore if the file belongs to one commit only.
+
+## Stash + Worktree for Moving Uncommitted Drift to a New Branch
+
+When main has uncommitted drift that belongs on a different branch (e.g., multi-session accumulation), use stash as the transport into a fresh worktree:
+
+```bash
+git stash push -u -m <label>                    # -u includes untracked
+git worktree add ../<path> -b <branch>          # from main HEAD
+cd ../<path> && git stash pop                   # pop applies in new worktree
+```
+
+Stashes live in the shared `.git` dir, so `pop` in any worktree of the same repo applies the stash there. Working tree state including untracked files transfers cleanly. Complementary to "use worktrees to avoid stashing" (§ Worktrees for Claude Code Settings Isolation) — here stash is the transport mechanism, not a workaround to avoid.
 
 ## Rebase `--onto` After Upstream Squash Merge
 

--- a/claude/learnings/git-patterns.md
+++ b/claude/learnings/git-patterns.md
@@ -622,6 +622,18 @@ These destroy untracked files, uncommitted changes, or both — with no recovery
 git stash --include-untracked -m "pre-reset-$(date +%Y%m%d-%H%M%S)"
 ```
 
+## Verify Source Clean After `git stash push -- <path>`
+
+`git stash push -- <pathspec>` is documented to revert the pathspec in the working tree after saving it, but a `.git/index.lock` race during compound `stash push && cd <worktree> && stash pop` can leave the stash created **and** the source file still dirty. Result: both source and destination end up with the same diff.
+
+Verify after push:
+```bash
+git stash push -m <label> -- <path>
+git diff --stat <path>   # must be empty; if not, the revert silently failed
+```
+
+Mitigation: run `stash push` and the cross-worktree `stash pop` as separate tool calls so any lock contention surfaces loudly instead of being swallowed by `&&` short-circuit.
+
 ## Cross-Refs
 
 - `~/.claude/learnings/bash-patterns.md` — shell escaping gotchas for git commands

--- a/claude/learnings/python-specific.md
+++ b/claude/learnings/python-specific.md
@@ -605,6 +605,20 @@ Verify the boundary holds before relying on it: grep production entry points' tr
 
 `uv.lock` still pins the dep (`--frozen` respects it), so dev builds are reproducible; only the image venv stays clean.
 
+## `sys.modules` Pre-Mock Unblocks `__init__.py` Singleton Exports
+
+Singletons exported from a package's `__init__.py` (e.g. `schwab_adapter = _SchwabAdapter()`) are normally test-hostile — instantiation runs at import time, hitting credentials/network. The fix in `tests/conftest.py`:
+
+```python
+import sys
+from unittest.mock import MagicMock
+sys.modules["mypkg.client"] = MagicMock()  # BEFORE any test import touches mypkg
+```
+
+When tests later do `from mypkg import singleton`, Python finds the pre-mocked client module and `__init__.py`'s constructor runs against the mock. Singleton becomes test-safe without restructuring the production code.
+
+Constraint: the pre-mock must execute before the first import of the affected package — `conftest.py` at the test-root level satisfies this for pytest.
+
 ## Cross-Refs
 
 - `~/.claude/learnings/api-design.md` — consistent response shapes (the principle behind the Pydantic serialization recommendation)

--- a/claude/learnings/refactoring-patterns.md
+++ b/claude/learnings/refactoring-patterns.md
@@ -374,6 +374,21 @@ Decision rule: if the swap commit leaves `pytest` red until the data migration c
 
 The cutover commit may be hundreds of files by count (data add/delete churn). That's fine — what matters is logical coherence, not line count. Bisect granularity through a cutover is just "before/after the cutover" anyway.
 
+## `@patch` Decorators Break When Code Moves
+
+When extracting a function into a new module, every test `@patch("old_module.symbol")` referencing imports-at-the-old-location breaks silently — the patch targets a name that no longer exists in the new caller's namespace. Mock at the new import location: if `sleep` moved from `logic.plz.operations` into `logic.libs.execution`, patches must become `@patch("logic.libs.execution.sleep")`.
+
+Audit step after any extraction: `grep -r "@patch.*old_module" tests/` and rewrite each. Tests that still pass after the move are passing for the wrong reason — they're patching a no-op.
+
+## Closure State Dicts for Callback-Driven Helpers
+
+When extracting a callback loop (e.g., `retry_until_filled(place_fn, update_fn, ...)`), two patterns keep the signature small:
+
+1. **`place_fn` returns `Optional[tuple[...]]`** — `None` signals exit-early, tuple carries forward state. One signature covers normal, dry-run, and "nothing to do" paths without an extra `check_fn` parameter.
+2. **Closure state dicts** — when `update_fn` needs values `place_fn` computed (price, ticker, qty), use a mutable dict captured in closure scope. Avoids a separate context object or expanding the helper's signature.
+
+Both push state-passing into the caller's closures, keeping the helper itself stateless.
+
 ## Cross-Refs
 
 - `~/.claude/learnings/code-quality-instincts.md` — code quality signals that trigger refactors

--- a/claude/learnings/review-conventions.md
+++ b/claude/learnings/review-conventions.md
@@ -165,6 +165,10 @@ Before flagging a path reference as stale due to a sibling rename, verify whethe
 
 **Reviewer test:** find the config (`*.json`, `*.toml`, `*.yaml`) that names the path. If it still references the old name, the references are correct — don't post the finding.
 
+### GitHub review comments don't track stale-against-fixed-code state
+
+The GitHub review API doesn't mark inline comments as stale when the underlying code was fixed in a subsequent commit. A comment posted against line X of commit A will appear as "active" even if commit B fixed the issue. Addressers must read current file state (+ git log for the touched lines) before implementing — otherwise they'll redo or conflict with prior fixes. Cross-reference the comment's commit SHA with `git log --oneline <path>` to see if fixes landed after.
+
 ## Cross-Refs
 
 - `~/.claude/learnings/process-conventions.md` — PR/MR scoping and workflow patterns (complementary: workflow vs review)

--- a/claude/learnings/review-conventions.md
+++ b/claude/learnings/review-conventions.md
@@ -169,6 +169,12 @@ Before flagging a path reference as stale due to a sibling rename, verify whethe
 
 The GitHub review API doesn't mark inline comments as stale when the underlying code was fixed in a subsequent commit. A comment posted against line X of commit A will appear as "active" even if commit B fixed the issue. Addressers must read current file state (+ git log for the touched lines) before implementing — otherwise they'll redo or conflict with prior fixes. Cross-reference the comment's commit SHA with `git log --oneline <path>` to see if fixes landed after.
 
+### Batch-Import PRs: Cross-File Invocation Drift
+
+Batch-import PRs that wire a new helper into multiple files in parallel often drift on the invocation format — e.g., `sweep-results.sh <run-dir>` (bare) in one file vs `bash ~/.claude/skill-references/sweep-results.sh <run-dir>` (fully-qualified) in another. The bare form silently fails at runtime because the script isn't on `$PATH`. Drift arises from parallel edits that don't cross-check.
+
+Review heuristic: when a PR introduces a new helper script/tool and wires it into 3+ files, grep across the diff for the invocation and verify all sites use the same form. A single canonical invocation per helper, documented in the script header or a nearby index, prevents the drift.
+
 ## Cross-Refs
 
 - `~/.claude/learnings/process-conventions.md` — PR/MR scoping and workflow patterns (complementary: workflow vs review)

--- a/claude/skill-references/director-playbook.md
+++ b/claude/skill-references/director-playbook.md
@@ -124,7 +124,7 @@ First cycle: full table. Subsequent cycles: delta-only (changed rows), with a on
 After every runner completion in compound mode, the director executes this decision tree automatically — no operator prompt needed:
 
 1. **Address runner completes** → read review `results.md`. If findings > 0 this cycle → relaunch review to verify resolution. If all resolved → check address convergence (all PRs terminal?).
-2. **Review runner completes** → read `results.md`. If findings posted (inline comments > 0 OR thread replies > 0) → relaunch address. If skipped or 0 findings → review converging, start 30m skip window.
+2. **Review runner completes** → read `results.md`. If **new** findings posted (new inline comments > 0 OR new thread replies > 0) → relaunch address. If skipped or 0 new findings → review converging, start 30m skip window. **A re-review body declaring "0 new findings, N prior resolved" is NOT findings posted** — `milestone: posted` with 0 new work means the loop is converging, don't relaunch.
 3. **Both converged** → proceed to Phase 5.
 
 "Runner completed" ≠ "converged." A completed runner means one cycle finished — convergence requires the domain rules above to be satisfied.
@@ -264,7 +264,9 @@ This is the pattern used for the framework PR (PR 79) built mid-session on its o
 
 ## Worker Learnings Triage
 
-During convergence wrap-up (Phase 5), the director must triage worker learnings before closing the session:
+During convergence wrap-up (Phase 5), the director must triage worker learnings before closing the session. **Invoke `/sweep:compound-agent-learnings <run-dir>` to handle this end-to-end** — it reads all `*/learnings.md` files, assesses observations for promotion, and presents candidates in the standard Type/Scope/Utility table format. Don't triage manually; the dedicated skill is more thorough and consistent.
+
+Manual fallback (if the skill is unavailable or you need custom scoping):
 
 1. **Read** each completed run's `*/learnings.md` files.
 2. **Assess** each observation for promotion:

--- a/claude/skill-references/parallel-claude-runner-template.sh
+++ b/claude/skill-references/parallel-claude-runner-template.sh
@@ -273,6 +273,17 @@ process_item() {
             printf '### attempt %d ###\n' "$attempt" >> "$item_dir/raw.jsonl"
         fi
 
+        # Compute CWD prefix — address mode launches the session inside the item's worktree
+        # so plain git commands operate on the PR branch (no cd/-C which trip hook-injection gate)
+        local cd_prefix=""
+{{#WORKTREES}}
+        local _wt
+        _wt=$(worktree_for "$item_num")
+        if [ -n "$_wt" ] && [ -d "$_wt" ]; then
+            cd_prefix="cd \"$_wt\" && "
+        fi
+{{/WORKTREES}}
+
         # Launch with stream monitoring if monitor exists, otherwise fall back to plain pipe
         if [ -x "$monitor" ]; then
             {
@@ -282,7 +293,7 @@ process_item() {
                     cat "${item_dir}/prompt.txt"
                 fi
             } \
-                | sh -c "echo \$\$ > ${item_dir}/session.pid; exec claude -p --model $MODEL --verbose --output-format stream-json $resume_flag" \
+                | sh -c "echo \$\$ > ${item_dir}/session.pid; ${cd_prefix}exec claude -p --model $MODEL --verbose --output-format stream-json $resume_flag" \
                 | "$monitor" "$item_dir" \
                 | tee -a "$item_dir/raw.jsonl" >> "$log_file" &
             local pipe_pid=$!
@@ -320,7 +331,7 @@ process_item() {
             fi
         else
             local fallback_timeout=$((INACTIVITY_TIMEOUT_SEC * 2))
-            if timeout "$fallback_timeout" sh -c "cat \"\$1\" | claude -p --model $MODEL 2>&1 | tee -a \"\$2\"" _ "${item_dir}/prompt.txt" "$log_file"; then
+            if timeout "$fallback_timeout" sh -c "${cd_prefix}cat \"\$1\" | claude -p --model $MODEL 2>&1 | tee -a \"\$2\"" _ "${item_dir}/prompt.txt" "$log_file"; then
                 exit_status="success"
             else
                 local fallback_rc=$?
@@ -422,7 +433,10 @@ process_item() {
 }
 
 export -f process_item write_state is_terminal_state
-export RUN_DIR INACTIVITY_TIMEOUT_SEC MAX_ATTEMPTS MODEL MODE_LABEL ENTITY_PREFIX ENTITY_LABEL STATE_FIELD TERMINAL_STATES
+{{#WORKTREES}}
+export -f worktree_for branch_for
+{{/WORKTREES}}
+export RUN_DIR INACTIVITY_TIMEOUT_SEC MAX_ATTEMPTS MODEL MODE_LABEL ENTITY_PREFIX ENTITY_LABEL STATE_FIELD STATE_CHECK_CMD TERMINAL_STATES
 
 # --- Launch ---
 printf '%s\n' "${ITEMS[@]}" | xargs -P "$CONCURRENCY" -I {} bash -c 'process_item "$@"' _ {}

--- a/claude/skill-references/parallel-claude-runner-template.sh
+++ b/claude/skill-references/parallel-claude-runner-template.sh
@@ -436,7 +436,7 @@ export -f process_item write_state is_terminal_state
 {{#WORKTREES}}
 export -f worktree_for branch_for
 {{/WORKTREES}}
-export RUN_DIR INACTIVITY_TIMEOUT_SEC MAX_ATTEMPTS MODEL MODE_LABEL ENTITY_PREFIX ENTITY_LABEL STATE_FIELD STATE_CHECK_CMD TERMINAL_STATES
+export RUN_DIR INACTIVITY_TIMEOUT_SEC MAX_ATTEMPTS MODEL MODE_LABEL ENTITY_PREFIX ENTITY_LABEL STATE_FIELD TERMINAL_STATES
 
 # --- Launch ---
 printf '%s\n' "${ITEMS[@]}" | xargs -P "$CONCURRENCY" -I {} bash -c 'process_item "$@"' _ {}


### PR DESCRIPTION
## Summary

- New `/sweep:compound-agent-learnings` skill promotes per-agent `learnings.md` observations into the global learnings system during Phase 5 wrap-up
- `sweep:work-items` runner template split from the generic PR-centric template (eliminates sed-patches for issue semantics)
- `sweep-status-summary.sh` / `sweep-results.sh` helpers wired into director + scaffold, replacing permission-prompting `for pr in …; do cat …` loops
- `/git:create-request` now handles uncommitted changes inline with a multi-concern flag
- New skill-task learnings gate in the search protocol for complex/long-running skills (sweeps, multi-agent, refactors)
- Misc technical learnings across bash (`xargs` subshell scoping), gitlab (`glab` state casing + `-F` flag semantics), python (`sys.modules` pre-mock for singletons), refactoring (`@patch` post-extraction, closure state dicts), review (stale inline comments)

## Commits

- `refactor(sweep:work-items): split runner template from generic PR template`
- `feat(sweep): wire sweep-status-summary.sh / sweep-results.sh into director + scaffold`
- `feat(sweep): add /sweep:compound-agent-learnings skill for wrap-up learnings promotion`
- `feat(guidelines): add skill-task learnings gate for complex/long-running skills`
- `feat(git:create-request): handle uncommitted changes inline with multi-concern flag`
- `refactor(learnings:compound): early-exit on single-provider multi-write`
- `docs(learnings): batch-add technical learnings across bash, gitlab, python, refactoring, review`

## Screenshots

N/A

## Test plan

- [ ] `setup-claude.sh` re-run symlinks `commands/sweep/compound-agent-learnings/` into `~/.claude/`
- [ ] `/sweep:compound-agent-learnings <run-dir>` appears in the skill list and runs against a populated sweep run
- [ ] `bash ~/.claude/skill-references/sweep-status-summary.sh <run-dir>` reads status across `pr-*/` and `issue-*/` layouts without prompting
- [ ] `/git:create-request` on a dirty base branch surfaces the new branching options

---
Generated with [Claude Code](https://claude.ai/code)
