### PR TITLE
chore: skill-references INDEX + skills/learnings refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ This repo (dotfiles) stores Claude Code config under `claude/` (not `.claude/`).
 
 For Glob/Grep use `claude/` CWD-relative paths. For Edit/Write either `~/.claude/` or `claude/` paths work.
 
+**Read/Edit path matching:** Edit's "recent Read" check is path-string-keyed, not realpath-keyed. A Read via `claude/foo.md` doesn't satisfy a follow-up Edit on `~/.claude/foo.md` (or vice versa) — the symlink topology means both resolve to the same file, but the tool tracks the literal string. Pair Read + Edit on the same path form.
+
 ## Bash Script Invocation
 
 When invoking generated scripts via `bash`, use the **CWD-relative path** that matches the permission pattern, not an absolute path. Permission patterns are literal-string-matched: `Bash(bash tmp/claude-artifacts/**)` matches `bash tmp/claude-artifacts/.../let-it-rip.sh` but **not** `bash /Users/.../dotfiles/tmp/claude-artifacts/.../let-it-rip.sh`. Absolute paths bypass the pattern and trigger an approval prompt.

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -19,6 +19,8 @@ Avoid quoted strings in Bash commands (e.g., `echo "---"`, `echo "DONE"`). Quote
 
 Check `pwd` before assuming you need to change directories. Don't `cd` or `git -C` into CWD — permission patterns match `git status`, not `cd /path && git status` or `git -C /path status`, so either forces manual approval. When targeting a different directory, prefer a single `cd` over repeated `git -C` — `cd` prompts once, `-C` prompts on every command.
 
+Before complex Bash (loops, `gh -q '<format>'` quoted format strings, multi-step pipes), check `~/.claude/skill-references/INDEX.md` for an allowlisted helper. The infrastructure invests in `bash ~/.claude/skill-references/**` wrappers; reaching for them keeps the operator out of the permission-prompt loop. The INDEX distinguishes executable wrappers (`bash <path> <args>`), templates (consumed by `fill-template.sh`), and platform command stubs (`{github,gitlab}/commands/*.sh` — read the file, run the underlying CLI directly).
+
 # Read Tool
 
 Prefer offset + limit over full re-reads. After reading a file once, note line numbers for sections you'll need later. Don't re-read to verify an Edit — trust the success message or use a 5-line targeted read. Avoid reading a file in full right before a Write when you already have the content in context. Every unnecessary Read costs ~200-500 tokens; across a multi-file refactor with multiple passes, that compounds to 2-5k+ wasted tokens.

--- a/claude/commands/explore-repo/SKILL.md
+++ b/claude/commands/explore-repo/SKILL.md
@@ -234,11 +234,13 @@ This phase runs in a fresh invocation with a clean context. Read domain files fr
 
    Write a **cross-domain overview** — this is the unique value that individual domain files cannot provide on their own. Do NOT simply concatenate the domain files.
 
+   **Format rules (same as domain files):** default to tables for parallel data and ASCII diagrams for flows / relationships; prose only when neither fits; cap section intros at 3 sentences; omit a section if its tables/diagrams already convey it.
+
    Structure:
    - **Scan metadata** as HTML comment at the top (commit, branch, date, dimensions)
-   - **Project Summary** (2-3 paragraphs): What the system does, key architectural decisions, technology choices. Synthesize insights from ALL domain files.
-   - **Architecture Overview**: How the major components connect. Cross-reference structure, data model, integrations, and processing flows.
-   - **Module Dependency Graph**: ASCII art showing how the major modules/packages depend on each other. Use box-drawing characters. Show the data flow direction. Example format:
+   - **Project Summary** (≤3 sentences) of what the system does. Follow with a one-line bullet list of architectural decisions and technology choices.
+   - **Architecture Overview** (≤3 sentences) introducing the diagram below.
+   - **Module Dependency Graph**: ASCII art showing how the major modules/packages depend on each other. Use box-drawing characters and show data flow direction. Example:
      ```
      ┌─────────────┐     ┌──────────────┐
      │  API Layer   │────▶│ Service Layer │
@@ -250,44 +252,52 @@ This phase runs in a fresh invocation with a clean context. Read domain files fr
              │ Adapters  │ │   DB    │ │  Events  │
              └──────────┘ └─────────┘ └──────────┘
      ```
-   - **Cross-Cutting Patterns**: Shared patterns that span multiple domains — authentication, error handling, naming conventions, transaction management, retry strategies.
-   - **Key Workflows End-to-End**: Trace the most important business flows through the full stack (API → service → data → integrations → events). Reference specific domain files for deeper detail.
-   - **Critical Path to Productivity**: A recommended reading order for a developer new to the codebase. List 5-8 files/docs in priority order, with a one-line explanation of what each teaches you. Start with the highest-leverage context (e.g., "1. CLAUDE.md — project overview and essential commands") and end with deep-dives. This section answers: "If I only have 30 minutes, what should I read?"
-   - **Resilience Assessment**: Cross-reference the integrations domain file to produce a consolidated view of resilience coverage across all external services. For each integration, report:
-     - Retry logic: present/absent (and mechanism if present)
-     - Timeouts: configured/unconfigured
-     - Circuit breaker: present/absent
-     - Idempotency keys: used/not used
-     Format as a table for quick scanning. Flag the overall posture (e.g., "0 of 7 integrations have retry logic") and note any integrations that are outliers (better or worse than the norm).
-   - **Test Coverage Gaps**: Cross-reference the structure and testing domain files to identify source modules with no corresponding test file. List untested modules with a brief note on their risk level (e.g., "core business logic — high risk" vs "utility formatting — low risk"). This is structural coverage (test file exists), not line-level coverage.
-   - **Documentation Gaps**: What's missing from existing docs, categorized by severity:
-     - **Critical** — Missing documentation that blocks productivity
-     - **Medium** — Missing but inferable from code
-     - **Low** — Nice-to-have improvements
-   - For each gap: what's missing, where it should be documented, suggested content
+   - **Cross-Cutting Patterns** — table:
+     | Pattern | Domains | Mechanism | Notes |
+     |---------|---------|-----------|-------|
+     (auth, error handling, naming conventions, transactions, retries, etc.)
+   - **Key Workflows End-to-End** — for each top workflow:
+     - ASCII flow diagram (API → service → data → integrations → events)
+     - Step table: `| # | Step | Layer | File:line | Notes |`
+     - Cross-refs to domain files for deeper detail
+   - **Critical Path to Productivity** — 5–8 files in reading order, table:
+     | Order | File | What it teaches |
+     |-------|------|------------------|
+     Answers "If I only have 30 minutes, what should I read?"
+   - **Resilience Assessment** — table per integration:
+     | Service | Retry | Timeout | Circuit breaker | Idempotency |
+     |---------|-------|---------|-----------------|-------------|
+     Cells show mechanism if present, blank if absent. Below the table: one-line overall posture (e.g., "0 of 7 integrations have retry logic") and call out outliers.
+   - **Test Coverage Gaps** — table, sorted by risk:
+     | Module | Test file? | Risk | Notes |
+     |--------|------------|------|-------|
+     Structural coverage only (test file exists), not line-level.
+   - **Documentation Gaps** — table:
+     | Severity | What's missing | Where it should go | Suggested content |
+     |----------|----------------|---------------------|--------------------|
+     Severities: **Critical** (blocks productivity) · **Medium** (inferable from code) · **Low** (nice-to-have).
 
 5. **Synthesize inconsistencies.md:**
 
-   Compare existing CLAUDE.md and README.md against what the scan actually found. Only write this file if existing docs were found — if there are no docs, skip it.
+   Compare existing CLAUDE.md and README.md against what the scan actually found. Only write this file if existing docs were found — if there are no docs, skip it. Same format rules as SYSTEM_OVERVIEW.md: tables-first, prose only when needed.
 
-   **Doc-vs-code inconsistencies:**
-   - Find specific discrepancies: the doc says X but the code does Y
-   - Categorize by severity:
-     - **Critical** — Actively misleading (wrong commands, incorrect architecture)
-     - **Medium** — Partially wrong (incomplete flows, outdated patterns)
-     - **Low** — Minor inaccuracies (stale versions, outdated links)
-   - For each inconsistency, include:
-     - **Doc source:** file path and section name
-     - **What it claims:** the incorrect content
-     - **What the code actually does:** the correct behavior with evidence (file path, line)
-     - **Suggested fix:** the exact replacement text or edit needed to correct the documentation
+   **Doc-vs-code inconsistencies** — table:
+   | Severity | Doc source (file § section) | Claim | Reality (file:line) | Suggested fix | Status |
+   |----------|------------------------------|-------|---------------------|----------------|--------|
 
-   **Config artifact drift** (separate section):
-   Cross-reference configuration templates and declarations against their canonical code sources. Common checks:
-   - `.env.template` / `.env.example` vs the canonical env var definitions in code (e.g., `env_vars.py`, `config.ts`, `application.properties`) — flag variables present in template but absent in code (dead), and variables in code but missing from template (undocumented)
+   Severities:
+   - **Critical** — actively misleading (wrong commands, incorrect architecture)
+   - **Medium** — partially wrong (incomplete flows, outdated patterns)
+   - **Low** — minor inaccuracies (stale versions, outdated links)
+
+   Status column carries the auto-fix outcome (see step 7): `[FIXED]` or `[UNFIXED — reason]`.
+
+   **Config artifact drift** — separate table with the same columns. Cross-reference configuration templates and declarations against their canonical code sources:
+   - `.env.template` / `.env.example` vs canonical env var definitions in code (e.g., `env_vars.py`, `config.ts`, `application.properties`) — flag variables present in template but absent in code (dead), and variables in code but missing from template (undocumented)
    - CI pipeline commands vs actual build system commands (e.g., CI runs `npm test` but `package.json` defines `yarn test`)
    - Dockerfile base image versions vs project-level version declarations (e.g., `python:3.11` in Dockerfile vs `3.12` in `pyproject.toml`)
-   Only check artifacts that exist — skip silently if the project has no templates or CI config. Format findings the same way as doc inconsistencies (source, claim, reality, fix).
+
+   Skip silently if no templates or CI config exist.
 
 6. **Add cross-references between domain files:**
 

--- a/claude/commands/explore-repo/SKILL.md
+++ b/claude/commands/explore-repo/SKILL.md
@@ -88,6 +88,7 @@ Determine what work needs to be done by checking existing output files.
 
    - Only re-scan domains whose files were **materially** affected by the changes. Apply judgment: a 2-line property addition won't change a 350-line config scan, and adding test cases to an existing test file won't change the testing infrastructure scan. Re-scan when the changes would meaningfully alter the domain file's content (new integrations, new entities, new test patterns), not when they're incremental additions to existing patterns. When in doubt, stamp-update rather than re-scan.
    - If the diff is too large (100+ files changed) or the mapping is ambiguous, fall back to re-scanning all stale domains
+   - **If `<stale-commit>` is unreachable** (e.g., scan was run on a deleted feature branch like `claude/create-feature-branch-*`), `git diff` and `git log` against it will fail. Detect via `git rev-parse <stale-commit>` returning non-zero, then fall back to re-scanning all stale domains. Don't try to find a nearest-ancestor — it's not worth the heuristic complexity.
    - **Important:** If `CLAUDE.md` or `README.md` changed, mark ALL domains for re-scan (project-level docs affect all agents' context)
 
 4. **Clean up stale synthesis files:**

--- a/claude/commands/explore-repo/agent-prompts.md
+++ b/claude/commands/explore-repo/agent-prompts.md
@@ -25,6 +25,14 @@ DO NOT DOCUMENT:
 - Boilerplate sections with nothing notable to say — if a section would just say "nothing unusual here", omit it entirely
 - Transitive dependencies or internal implementation details of third-party libraries
 
+FORMAT:
+- Default to tables for parallel data (per-item attributes), ASCII diagrams for flows / relationships / state machines.
+- Prose only when neither table nor diagram fits; cap section intros at 3 sentences.
+- Omit Overview if Key Findings + tables already convey it.
+- Key Findings: ≤7 bullets, one line each. Prefer file:line references over restating what a table already shows.
+- Gotchas: one-line bullets with file:line refs.
+- Do not restate column headers in prose alongside a table.
+
 PATH FORMAT:
 - ALWAYS use repo-relative paths (e.g., `backend/src/main/java/...`), NEVER absolute paths (e.g., `/Users/.../backend/...`).
 - This applies to all file references in your output — entity locations, script paths, config files, test files, etc.
@@ -109,25 +117,29 @@ For deployment: Docker setup, container relationships, deployment scripts.
 # Structure
 
 ## Project Overview
-[1-2 paragraphs: what this project is, how it's organized, key technology choices]
+[≤3 sentences: what it is, how it's organized, primary tech. Omit if Key Findings + tables cover it.]
 
 ## Key Findings
-[3-7 most important non-obvious discoveries]
+[≤7 bullets, one line each]
 
 ## Modules
-For each module: name, purpose, location, entry point, key dependencies, relationships to other modules.
+| Module | Location | Purpose | Entry point | Depends on |
+|--------|----------|---------|-------------|------------|
 
 ## Build System
-Tool, build commands (full project + per-module), test/lint/format commands, profiles/configurations.
+| Operation | Command | Notes |
+|-----------|---------|-------|
+[build full / build module / test / lint / format / per-profile invocations]
 
 ## Dependencies
-[Key external dependencies that define the project's character — not every utility library]
+[Only deps that constrain behavior — one-line each: `lib X@version — constrains Y`. Omit if none.]
 
 ## CI/CD Pipeline
-[Pipeline stages, triggers, what each does]
+| Stage | Trigger | Does | Artifacts |
+|-------|---------|------|-----------|
 
 ## Deployment
-[Docker setup, containers, deployment scripts]
+[ASCII container diagram if multi-container; else table: `| Component | Image / script | Purpose |`]
 
 ## Scripts & Utilities
 | Script | Purpose |
@@ -135,7 +147,7 @@ Tool, build commands (full project + per-module), test/lint/format commands, pro
 | [path] | [what it does] |
 
 ## Gotchas
-[Non-obvious patterns that would surprise a developer new to this codebase]
+[One-line bullets with file:line refs]
 
 ## Scan Limitations
 [Coverage gaps and areas not fully explored]
@@ -197,30 +209,34 @@ Also: API versioning strategy, common error response format, pagination patterns
 # API Surface
 
 ## Endpoints Overview
-[Count, groupings, versioning strategy]
+[≤3 sentences: count, groupings, versioning strategy. Omit if Key Findings + tables cover it.]
 
 ## Key Findings
-[3-7 most important non-obvious discoveries]
+[≤7 bullets, one line each]
 
 ## REST Endpoints
-Group by controller/resource. For each group, provide an endpoint table:
-| Method | Path | Description | Auth |
-|--------|------|-------------|------|
+Group by controller/resource. For each group:
+| Method | Path | Description | Auth | Request | Response |
+|--------|------|-------------|------|---------|----------|
 
 ## Request/Response Models
-For each important model: name, which endpoints use it, key fields with types.
+| Model | Used by | Key fields (name: type) |
+|-------|---------|--------------------------|
 
 ## gRPC / GraphQL / Other Interfaces
-[If applicable: service names, methods, schema, WebSocket endpoints, CLI commands]
+[If applicable, same tabular treatment: `| Service.method | Schema | Notes |`. Omit if none.]
 
 ## API Conventions
-Versioning, error format, pagination pattern, authentication mechanism, validation approach.
+| Aspect | Convention |
+|--------|------------|
+[versioning, error format, pagination, auth mechanism, validation, CORS]
 
 ## Middleware & Filters
-[What exists, execution order, what each does]
+| Order | Filter / Middleware | Purpose | File:line |
+|-------|---------------------|---------|-----------|
 
 ## Gotchas
-[Non-obvious patterns that would surprise a developer new to this codebase]
+[One-line bullets with file:line refs]
 
 ## Scan Limitations
 [Coverage gaps and areas not fully explored]
@@ -291,31 +307,41 @@ Use Glob and Grep to find, then read every match:
 # Data Model
 
 ## Overview
-[Entity count, key relationships, database technology]
+[≤3 sentences: entity count, DB tech. Omit if Key Findings + ER diagram cover it.]
 
 ## Key Findings
-[3-7 most important non-obvious discoveries]
+[≤7 bullets, one line each]
 
 ## Core Entities
-For each entity: table/collection name, purpose, key fields (name, type, description), relationships (direction, cardinality, join), special handling (encryption, auditing, soft delete).
+For each entity, one subsection with:
+- One-line purpose
+- Fields table: `| Field | Type | Notes |` (notes = annotations, constraints, encryption, soft-delete)
+- Relationships table (if any): `| Relation | Cardinality | Target | Join |`
 
 ## Entity Relationships
-[Prose description or text diagram showing how major entities connect]
+[ASCII ER diagram. Boxes for entities, labeled arrows with cardinality (`1—*`, `*—*`). Prose only as fallback.]
 
 ## State Machines
-For each status flow: ASCII state diagram, transition triggers, and conditions.
+For each state flow:
+- ASCII state diagram (boxes for states, labeled arrows for transitions)
+- Transition table: `| From | To | Trigger | Conditions |`
 
 ## Database Details
-Database technology, schema, key views, notable indexes, important constraints.
+| Aspect | Value |
+|--------|-------|
+[engine, schema name, notable views, indexes, constraints — one row each]
 
 ## Data Patterns
-Encryption, auditing, soft deletes, converters, versioning — whatever patterns exist.
+| Pattern | Where | Mechanism |
+|---------|-------|-----------|
+[encryption, auditing, soft deletes, converters, versioning]
 
 ## Migration Highlights
-[Notable structural changes — new tables, major alterations, data migrations]
+| Migration | Type | Change |
+|-----------|------|--------|
 
 ## Gotchas
-[Non-obvious patterns that would surprise a developer new to this codebase]
+[One-line bullets with file:line refs]
 
 ## Scan Limitations
 [Coverage gaps and areas not fully explored]
@@ -385,28 +411,36 @@ Also: shared HTTP client config, common retry patterns, timeout defaults, connec
 # Integrations
 
 ## Overview
-[External service count, common patterns]
+[≤3 sentences: service count, dominant patterns. Omit if Key Findings + tables cover it.]
 
 ## Key Findings
-[3-7 most important non-obvious discoveries]
+[≤7 bullets, one line each]
 
 ## External Services
-For each service: purpose, type (REST/gRPC/SDK/Queue/Webhook), auth method, key operations, error handling strategy, config required, code location.
+| Service | Type | Auth | Key operations | Resilience | Config | Code |
+|---------|------|------|----------------|------------|--------|------|
+(Type: REST / gRPC / SDK / Queue / Webhook. Resilience: list what's present — retry / timeout / circuit-breaker / idempotency.)
 
 ## Integration Patterns
-HTTP client library, retry strategy, circuit breaker approach, timeout defaults, connection pooling.
+| Aspect | Value |
+|--------|-------|
+[HTTP client library, retry strategy, circuit breaker approach, timeout defaults, connection pooling]
 
 ## Authentication Summary
-[Shared auth patterns, token management, credential storage]
+| Pattern | Used by | Token / credential management |
+|---------|---------|--------------------------------|
 
 ## Message Queues / Async
-[If applicable: technology, topics/queues, producers, consumers, message formats]
+| Tech | Topic / Queue | Producer | Consumer | Message format |
+|------|----------------|----------|----------|----------------|
 
 ## Webhook System
-[If applicable: registration, delivery, signature verification, retry]
+| Aspect | Mechanism |
+|--------|-----------|
+[registration, delivery, signature verification, retry]
 
 ## Gotchas
-[Non-obvious patterns that would surprise a developer new to this codebase]
+[One-line bullets with file:line refs]
 
 ## Scan Limitations
 [Coverage gaps and areas not fully explored]
@@ -487,32 +521,39 @@ Use Glob and Grep to find, then read every match:
 # Processing Flows
 
 ## Overview
-[Key business domain, main workflows, processing philosophy]
+[≤3 sentences: business domain, main workflows. Omit if Key Findings + diagrams cover it.]
 
 ## Key Findings
-[3-7 most important non-obvious discoveries]
+[≤7 bullets, one line each]
 
 ## Core Workflows
-For each workflow: trigger, numbered steps with service/method references, outcome, error handling, code location.
+For each workflow:
+- ASCII flow diagram (trigger → steps → outcome; show branches for error paths)
+- Step table: `| # | Step | Service.method | Notes |`
+- Error handling: one-line summary
 
 ## Scheduled Operations
 | Job | Schedule | Purpose | Location |
 |-----|----------|---------|----------|
 
 ## Event Flows
-For each event type: emitter, consumer(s), payload, side effects.
+| Event | Emitter | Consumer(s) | Payload | Side effects |
+|-------|---------|-------------|---------|--------------|
 
 ## Business Rules
-[Key validations, calculations, algorithms — the domain-specific rules that define correctness]
+| Rule | Where (file:line) | Logic |
+|------|-------------------|-------|
 
 ## Transaction Boundaries
-[Where boundaries exist, propagation strategies, rationale]
+| Boundary | Propagation | Rationale |
+|----------|-------------|-----------|
 
 ## Error & Recovery Flows
-[Retry, compensation, manual intervention, recovery jobs]
+| Failure mode | Recovery | Trigger | Location |
+|--------------|----------|---------|----------|
 
 ## Gotchas
-[Non-obvious patterns that would surprise a developer new to this codebase]
+[One-line bullets with file:line refs]
 
 ## Scan Limitations
 [Coverage gaps and areas not fully explored]
@@ -597,43 +638,51 @@ Use Glob and Grep to find, then read every match:
 # Configuration & Operations
 
 ## Overview
-[Configuration approach, key operational concerns]
+[≤3 sentences: config approach, operational shape. Omit if Key Findings + tables cover it.]
 
 ## Key Findings
-[3-7 most important non-obvious discoveries]
+[≤7 bullets, one line each]
 
 ## Configuration Hierarchy
-[Config sources and their precedence]
+| Precedence | Source | Notes |
+|------------|--------|-------|
+(Highest precedence first — runtime overrides, env vars, profile files, defaults.)
 
 ## Environment Profiles
-| Profile | Purpose | Key Differences |
+| Profile | Purpose | Key differences |
 |---------|---------|-----------------|
 
 ## Key Configuration Properties
-[Important properties grouped by category — only what matters for understanding and operating the system]
+| Category | Property | Default | Purpose |
+|----------|----------|---------|---------|
 
 ## Feature Flags
 | Flag | Default | Purpose |
 |------|---------|---------|
 
 ## Monitoring & Metrics
-Metrics (counters, timers, gauges), health checks, logging config (format, levels, destinations).
+| Metric / probe | Type (counter/timer/gauge/health) | Purpose | Location |
+|----------------|------------------------------------|---------|----------|
+
+Logging: one-line summary of format, levels, destinations.
 
 ## Secrets Management
-[How secrets are managed, what exists, where referenced. NO actual values.]
+| Secret | Source (vault/env/file) | Used by | Notes |
+|--------|--------------------------|---------|-------|
+(NO actual values — only names and references.)
 
 ## Deployment
-[How the app is deployed — Docker, K8s, scripts, manual]
+[ASCII deployment diagram if multi-container/K8s; else table: `| Component | How deployed | Notes |`]
 
 ## Operational Scripts
 | Script | Purpose | Usage |
 |--------|---------|-------|
 
 ## Local Development Setup
-[What's needed to run locally]
+Prereqs as one-line bullets above; numbered steps (≤7) below with exact commands.
 
 ## Gotchas
-[Non-obvious patterns that would surprise a developer new to this codebase]
+[One-line bullets with file:line refs]
 
 ## Scan Limitations
 [Coverage gaps and areas not fully explored]
@@ -707,36 +756,43 @@ Read every test utility, config, mock, and base class file. For actual test file
 # Testing
 
 ## Overview
-[Testing philosophy, maturity, coverage approach]
+[≤3 sentences: testing philosophy, maturity. Omit if Key Findings + tables cover it.]
 
 ## Key Findings
-[3-7 most important non-obvious discoveries]
+[≤7 bullets, one line each]
 
 ## Test Types
-| Type | ~Count | Location Pattern | Run Command |
+| Type | ~Count | Location pattern | Run command |
 |------|--------|------------------|-------------|
 
 ## Test Frameworks
-[Testing libraries and tools used]
+| Framework | Type (runner / assert / mock) | Used by |
+|-----------|-------------------------------|---------|
 
 ## Test Utilities & Base Classes
-For each: location, purpose, what it provides, which tests use it.
+| Utility / base | Location | Provides | Used by |
+|----------------|----------|----------|---------|
 
 ## Mocking Strategy
-| External Dependency | Mock Approach | Location |
-|--------------------|---------------|----------|
+| External dependency | Mock approach | Location |
+|---------------------|---------------|----------|
 
 ## Test Data Management
-[Factories, builders, fixtures, SQL seeds, transactional rollback — whatever approach is used]
+| Approach | Where | Used by |
+|----------|-------|---------|
+(factories, builders, fixtures, SQL seeds, transactional rollback, etc.)
 
 ## Test Patterns & Conventions
-[Naming conventions, setup/teardown, assertion style, organization]
+| Aspect | Convention |
+|--------|------------|
+(naming, setup/teardown, assertion style, organization)
 
 ## CI/CD Test Pipeline
-[Stages, parallelization, test reporting]
+| Stage | Parallelization | Reporting | Notes |
+|-------|------------------|-----------|-------|
 
 ## Gotchas
-[Non-obvious patterns that would surprise a developer new to this codebase]
+[One-line bullets with file:line refs]
 
 ## Scan Limitations
 [Coverage gaps and areas not fully explored]

--- a/claude/commands/git/address-request-comments/address-request-edge-cases.md
+++ b/claude/commands/git/address-request-comments/address-request-edge-cases.md
@@ -104,6 +104,14 @@ git checkout <original_branch>
 
 This keeps the review focused on its intended scope and makes reviews easier.
 
+## Re-read cited learning's detection criteria when pushing back on misapplied findings
+
+When a finding cites a learning (e.g., *Test-only state in production code signals wrong-level DI seam*) and the suggested change feels off, re-read the cited learning's detection criteria before drafting the pushback. Many learnings have explicit fingerprints — `_*_injected` flags, error messages mentioning "injected"/"mock"/"test path", runtime branches that exist only for tests — and a finding that doesn't match those fingerprints is mis-applying the learning.
+
+Pushback structure: name the criteria, point out the case doesn't match, suggest where the learning *would* apply. Example: *"the criteria are about test-only runtime branches in production; `_PERPETUAL_DAILY_DIR` is read identically in production and tests — `monkeypatch` repoints the filesystem location, not a code path."* Reviewers can concede on substance instead of on tone.
+
+Pairs with the "Push back when warranted" core principle — this is the *how* once you've decided to push back.
+
 ## After LGTM Verification
 
 After verifying and confirming an LGTM, note to the operator that the review is approved and further comment monitoring is unlikely to be needed. An approved review rarely receives new comments.

--- a/claude/commands/git/prune-merged/SKILL.md
+++ b/claude/commands/git/prune-merged/SKILL.md
@@ -34,12 +34,19 @@ Remove local branches that have already been merged into remote main.
 
    **Method B - Squash merges (remote branch deleted after PR merge):**
    ```bash
-   git branch -vv | grep ': gone]' | awk '{print $1}'
+   # Handle the `+ branch` prefix `git branch -vv` adds for worktree-attached
+   # branches — `awk '{print $1}'` would extract `+` and silently drop the branch.
+   git branch -vv | grep ': gone]' | awk '$1=="+"{print $2; next} {print $1}'
    ```
 
    Combine both lists, removing duplicates. This catches:
    - Branches with commits directly in origin/main history (regular merge)
    - Branches whose remote tracking branch was deleted after merge (squash merge)
+
+   **Bucket worktree-attached separately.** Lines starting with `+` in `git branch -vv`
+   are checked out in another worktree and cannot be deleted with `git branch -D` until
+   detached. Capture them so step 4 can list them as "blocked by worktree" rather than
+   attempting (and failing) to delete them, and so the operator sees what to detach.
 
 3. **Handle dry-run mode**:
    - If `$ARGUMENTS` contains `--dry-run`:
@@ -61,6 +68,17 @@ Remove local branches that have already been merged into remote main.
      |--------|-------------|
      | feature/auth | 3 days ago |
      | fix/login-bug | 1 week ago |
+     ```
+
+   - If any worktree-attached merged branches were captured in step 2, list them
+     in a separate "Blocked by worktree" table with the worktree path so the
+     operator can detach them and re-run:
+     ```
+     Blocked by worktree (skipped — detach with `git worktree remove <path>`):
+
+     | Branch | Worktree Path |
+     |--------|---------------|
+     | sweep/137-foo | tmp/.../worktrees/issue-137 |
      ```
 
    - Use `AskUserQuestion` to confirm:

--- a/claude/commands/git/team-review-request/persona-routing.md
+++ b/claude/commands/git/team-review-request/persona-routing.md
@@ -68,6 +68,12 @@ Precedence over heuristic matching. Forced personas count toward the utility-bas
 
 **Inject into correctness prompt:** "Focus on boundary validation (UUID parsing, enum mapping), null guards on SDK returns, exception cause-chain nullability, and silent pagination truncation."
 
+### Non-trivial size or thin-wrapper density → architecture-reviewer
+
+**Match:** PR adds 500+ new lines OR introduces 5+ new internal helper functions OR module docstrings exceeding ~30 lines.
+
+**Force:** `architecture-reviewer` — adds the readability-first lens. The defect-oriented personas (financial, correctness, claude-config) don't flag verbose code, near-duplicate helpers, or over-documented internals — those pass defect review and fail architecture review. If the cap excludes architecture-reviewer, recommend a follow-up `/simplify` pass.
+
 ---
 
 ## Merge Algorithm

--- a/claude/commands/git/team-review-request/re-review-mode.md
+++ b/claude/commands/git/team-review-request/re-review-mode.md
@@ -57,6 +57,10 @@ Build output lists:
 
 **Subagent-skip heuristic.** When `NEW_COMMITS` is small (< ~100 changed lines) and consists purely of remediation for prior findings — no new logic, no new attack surface, no domain expansion — the orchestrator can handle the re-review inline and skip subagent launches. Verify each "Fixed in `<sha>`" claim against branch HEAD code directly. This applies the team-lead "fewer high-quality findings > comprehensive coverage" instinct: subagent overhead isn't worth it when the delta is bounded and in known domains. When in doubt, launch.
 
+**Refining the line threshold: commit hygiene > line count.** The 100-line gate is a starting heuristic; the stronger signal is whether each fix commit's one-liner names its target finding (e.g., `fix(file_writer): per-writer tempfile so concurrent writers don't race`). With 1:1 commit-to-finding mapping, inline verification stays auditable past ~700 changed lines. Vague or bundled commits collapse the heuristic — fall back to subagent re-launch.
+
+**Inline verification reads whole-function context; subagents read the hunk.** Bugs that span the diff edge — e.g., a parse-time check on `args.ticker` that doesn't account for a default applied 30 lines later in `main()` — need the wider read. When the heuristic fires, read 5-10 lines around each fix anchor rather than re-running diff-scoped subagents.
+
 For each persona in `RE_REVIEW_PERSONAS` (when not skipped per the heuristic above):
 - Front-load persona content (same as step 6)
 - Launch as a foreground reviewer subagent, but with the diff scoped to `NEW_COMMITS` only

--- a/claude/commands/set-persona/claude-config-expert.md
+++ b/claude/commands/set-persona/claude-config-expert.md
@@ -10,7 +10,7 @@ Knowledge base for the Claude configuration surface: skills, guidelines, learnin
 - **Memory minimalism**: prefer guidelines (for rules), learnings (for knowledge), or skill references (for shared patterns) over memory. Memory is for facts that don't fit anywhere else — if the content would be useful to a skill or persona, it belongs in a discoverable file, not always-on context
 
 ## Content type placement
-> Full criteria: `provider:default/claude-authoring/content-types.md`
+> Full criteria: `provider:default/claude-authoring/routing-table.md`
 - Behavioral rule ("always do X") → guideline, not learning or memory
 - Domain knowledge (gotcha, recipe, pattern) → learning
 - Shared patterns consumed by 2+ skills → skill reference (`skill-references/`), not inlined in each skill
@@ -34,20 +34,24 @@ Knowledge base for the Claude configuration surface: skills, guidelines, learnin
 - Gotchas files must stay separate from parent domain files (never merge `*-gotchas.md` into parent)
 
 ## Proactive loads
-- `provider:default/claude-authoring/content-types.md`
+- `provider:default/claude-authoring/routing-table.md`
 
 ## Cross-Refs
 Load when working in the specific area:
-- `provider:default/claude-authoring/skills.md` — skill composition, creation heuristics, responsibility boundaries
+- `provider:default/claude-authoring/skill-design.md` — composition, creation heuristics, responsibility boundaries, validation patterns
 - `provider:default/claude-authoring/guidelines.md` — merging overlaps, enforcement gates, scoping
 - `provider:default/claude-authoring/claude-md.md` — conditional references, relationships, subdirectory criteria
 - `provider:default/claude-authoring/personas.md` — judgment vs recipes, proactive loads, composition
-- `provider:default/claude-authoring/learnings.md` — genericization, headers, scope, boundary tests, cross-refs, directories, indexes, splitting
-- `provider:default/claude-code/platform.md` — permission patterns, path resolution, platform behavior gotchas
+- `provider:default/claude-authoring/learnings-content.md` — genericization, headers, scope, boundary tests, cross-refs
+- `provider:default/claude-authoring/learnings-organization.md` — directories, indexes, splitting
+- `provider:default/claude-code/platform-permissions.md` — permission patterns, allowlist tuning
+- `provider:default/claude-code/platform-worktrees-and-isolation.md` — path resolution, worktree gotchas, isolation behavior
 - `provider:default/claude-code/skill-platform-portability.md` — frontmatter features, cross-platform compat, plugin packaging
 - `provider:default/code-quality-instincts.md` — universal code quality patterns referenced by personas
 - `provider:default/process-conventions.md` — PR scoping, review process, MR conventions
 - `~/.claude/commands/learnings/curate/curation-insights.md` — curation calibration, compression targets
 - `provider:default/claude-code/hooks.md` — hook authoring, PreToolUse/PostToolUse mechanics, selective allowlists
-- `provider:default/claude-code/multi-agent/patterns.md` — work distribution, synthesis, parallelization, staging, file coordination, verification, trust arc
+- `provider:default/claude-code/multi-agent/orchestration.md` — work distribution, synthesis, parallelization
+- `provider:default/claude-code/multi-agent/coordination.md` — file coordination, staging
+- `provider:default/claude-code/multi-agent/quality.md` — verification, trust arc
 - `provider:default/claude-code/multi-agent/parallel-plans.md` — parallel plan execution, DAG shape, speedup bounds

--- a/claude/commands/set-persona/correctness-reviewer.md
+++ b/claude/commands/set-persona/correctness-reviewer.md
@@ -47,4 +47,4 @@ Every finding MUST include inline code references — quote the exact problemati
 
 - `provider:default/resilience-patterns.md` — retry classification, fail-fast patterns, thundering herd
 - `provider:default/java/spring-boot-gotchas.md` — InterruptedException handling, @Retryable gotchas
-- `provider:default/java/concurrency-and-resources.md` — thread safety, interrupt flag, resource leaks
+- `provider:default/java/concurrency.md` — thread safety, ConcurrentMap/HashSet TOCTOU, per-entity polling/throttle

--- a/claude/commands/set-persona/java-backend.md
+++ b/claude/commands/set-persona/java-backend.md
@@ -39,7 +39,7 @@ Load when working in the specific area:
 - `provider:default/code-quality-instincts.md` — Universal code quality patterns: naming, logging, dead code, wrapper methods
 - `provider:default/aws/messaging.md` — SQS/SNS/EventBridge patterns: queue selection, idempotent consumers, DLQ config, backpressure, Spring Cloud AWS
 - `provider:default/postgresql-query-patterns.md` — Window functions, CTEs, JSONB operations, partial indexes, partitioning strategy
-- `provider:default/newman-postman.md` — Newman skipRequest gotchas, conditional assertions for idempotent seeding, export-environment manifest bridge
+- `provider:default/testing/newman-postman.md` — Newman skipRequest gotchas, conditional assertions for idempotent seeding, export-environment manifest bridge
 - `provider:default/local-dev-seeding.md` — Hybrid API + SQL seeding architecture, schema drift detection, deterministic seed UUIDs
 - `provider:default/java/infosec-gotchas.md` — JWT validation, CORS, secrets management, dependency vulnerabilities
 - `provider:default/java/observability-gotchas.md` — Logging pitfalls, metric cardinality, trace context propagation

--- a/claude/commands/set-persona/platform-engineer.md
+++ b/claude/commands/set-persona/platform-engineer.md
@@ -26,7 +26,7 @@
 
 ## Proactive Cross-Refs
 
-- `provider:default/gitlab-ci-cd.md`
+- `provider:default/cicd/gitlab.md`
 
 ## Cross-Refs
 
@@ -34,4 +34,5 @@ Load when working in the specific area:
 - `provider:default/aws/patterns.md` — EventBridge scheduling limits, ECS Fargate cost-aware defaults
 - `provider:default/git-patterns.md` — Parallel branch rebase with worktrees, pnpm lockfile conflicts, worktree settings isolation, zsh glob expansion
 - `provider:default/bash-patterns.md` — Shell env default ordering, shared test library pattern, `set -e`/`pipefail` traps, teardown ordering
-- `provider:default/gitlab-ci-cd.md` — GitLab CI/CD patterns, debugging with glab API, MR API endpoints, Docker build/push stage rules
+- `provider:default/cicd/gitlab-ci-patterns.md` — YAML anchors, Maven builds, BuildKit caching, pipeline optimization
+- `provider:default/cicd/gitlab.md` — glab CLI debugging, MR API endpoints, pipeline stage rules, CI guards

--- a/claude/commands/set-persona/python-engineer.md
+++ b/claude/commands/set-persona/python-engineer.md
@@ -1,0 +1,66 @@
+# Python Engineer Focus
+
+Lens for production-grade Python work — modern craft, testing rigor, and defensive boundaries. Language-only base lens; specialize via composition (`python-quant-dev`, etc.) when domain-specific judgments apply.
+
+## Domain priorities
+
+### Python craft
+- Type hints on every public signature; modern syntax (`list[int]`, `X | None`, `TypeAlias`, `Final`)
+- Composition over inheritance; `Protocol` for structural typing instead of ABCs when behavior is what matters
+- Explicit exceptions over bare `except`; no silent failures
+- No mutable default arguments; `dataclass(frozen=True, slots=True)` for value objects
+- Context managers for any resource that needs cleanup (files, connections, locks)
+- `logging` over `print` in anything beyond throwaway scripts
+- Google-style docstrings on public functions, classes, and modules — explain *why*, not *what*
+
+### Testing rigor
+- 80% coverage minimum for new code
+- Branch coverage, not just line coverage: `pytest --cov --cov-branch`
+- Mock external APIs at unit level — never make live calls in tests
+- Edge cases are mandatory test inputs: empty input, boundary values, malformed data, error paths
+- Mark integration tests with `@pytest.mark.integration` so they're separable from the fast suite
+- Mock at the import location, not where the function is defined: `@patch("pkg.mod.func")` where `mod` imports `func`
+
+## When reviewing or writing code
+
+- Reject `from foo import *` and module-level side effects (file I/O, network, mutable singletons at import time)
+- Push back on bare `except:` and `except Exception:` — name the exception you're catching
+- Flag mocks that don't match real API shape — coupling a test to a fictional contract hides production bugs
+- Watch for missing `numpy` boolean handling in assertions: `assert result == True`, not `is True` (numpy returns `np.bool_`, not Python `bool`)
+- For `talib` calls, verify float arrays — int input silently returns wrong values
+- Catch `dict.get(k) or fb` where `0`, `""`, `[]`, or `False` is a semantically valid value — use `dict.get(k, fb)` or `v if v is not None else fb`
+- `float(api_string)` accepts `'NaN'`, `'Infinity'`, sentinel values silently — guard with `math.isfinite(x)` and range checks for numeric API responses
+
+## When making tradeoffs
+
+- **Correctness over speed** — profile only after correctness is proven
+- **Readability over cleverness** — vectorized one-liners that need a comment to parse aren't worth the trade
+- **Defensive at boundaries, trusting inside** — validate at I/O edges (API responses, CSV ingest, env config); don't re-validate between internal pure functions
+- **Explicit over magic** — dependency injection over module-level singletons, named arguments over positional, type aliases over inline `Union[...]`
+- **Reproducibility over flexibility** — pinned dependencies, deterministic seeds, version-stamped outputs
+
+## Code style
+
+Enforce `provider:default/code-quality-instincts.md` (no duplication, single source of truth, port intent not idioms).
+
+## Proactive Cross-Refs
+
+Loaded eagerly because they apply to nearly every Python task:
+
+- `provider:default/python-specific.md` — Pydantic v2 quirks, TypedDict/NotRequired, `__post_init__`, `noqa` discipline, `pyproject.toml`/`uv` patch-path gotchas, `dict.get(k) or fb` family, `float()` accepting NaN/Infinity, `int()` on float-formatted strings
+- `provider:default/code-quality-instincts.md` — DRY, single source of truth, dead code, guard variables, log security, domain isolation, named guard variables, generic error messages
+- `provider:default/refactoring-patterns.md` — survey-first methodology, commit granularity, content-loss audits, parallel batch refactors, Docker smoke tests after CMD path changes
+- `provider:default/process-conventions.md` — three-source config drift, scope MRs tightly, follow-up issue filing, plan-first PR pattern
+
+## Cross-Refs
+
+Load on demand when the work touches the listed area:
+
+### Testing
+- `provider:default/testing/testing-patterns.md` — pytest isolation, module-level singleton pitfalls, import side effects, UTC datetime handling, mock coupling, cross-test leakage
+
+### Resilience
+- `provider:default/resilience-patterns.md` — retry/idempotency, dedup, circuit breakers, scheduler decoupling; load for service code that integrates with external APIs
+
+### Review
+- `provider:default/review-conventions.md` — inline comment shape, review etiquette, dissent handling; load when authoring or addressing review feedback

--- a/claude/commands/set-persona/python-quant-dev.md
+++ b/claude/commands/set-persona/python-quant-dev.md
@@ -1,0 +1,52 @@
+# Python Quant Dev Focus
+
+## Extends: python-engineer
+
+Composition persona for quant Python work. Inherits Python craft, testing rigor, and engineering tradeoffs from `python-engineer`. This layer covers only the quant/financial intersection — backtester correctness, market data integrity, and pitfalls that arise specifically when Python idioms meet trading-strategy code.
+
+## Domain priorities
+
+### Quant correctness
+- **No look-ahead bias**: today's decision uses information available *before* today's bar closes — never today's close, today's high/low, or any forward-derived field
+- **Point-in-time data discipline**: corporate actions (splits, dividends, mergers) applied as of effective date, not retroactively rewritten
+- **Transaction cost realism**: slippage, commission, and market impact modeled explicitly — a backtest without costs is marketing material, not evidence
+- **Survivorship bias awareness**: delisted/merged tickers must be present in the historical universe, not silently filtered out
+- **Out-of-sample discipline**: walk-forward and holdout validation are mandatory for any strategy claim; in-sample Sharpe is a hypothesis, not a result
+- **Reproducibility**: fixed random seeds, versioned data snapshots, all parameters logged — same input + same code = same output, always
+
+### Trading-logic test rigor (extends `python-engineer` testing)
+- **90%+ coverage** for trading logic — order routing, position sizing, signal generation, risk checks
+- Mock all broker APIs and market data feeds at unit level — never make live calls in tests
+- Edge cases mandatory: first/last bar, zero volume, market holidays, halts, missing data, extreme prices, vendor sentinel values for missing data
+
+## When reviewing or writing code (quant lens)
+
+- Flag any algo that reads `candle.close` for a decision keyed to that same candle's open — that's look-ahead
+- Question Sharpe ratios > 3 in equity strategies — usually leakage, p-hacking, or unmodeled costs
+- Watch for hardcoded backtest date ranges that happen to be the strategy's best window
+- Reject `float` for monetary precision-sensitive math; use integers (cents) or `Decimal` with explicit context
+- Catch `int(fiat_usd / price)` style fractional-share truncation drift in cumulative tests
+- After `float(api_string)`, guard with `math.isfinite(x) and x > 0` — vendor APIs return NaN, Infinity, and boundary-artifact sentinels (e.g., TradeStation's `-21_474_836.48`) for missing data; an unguarded float produces nonsensical limit prices
+
+## Proactive Cross-Refs
+
+Loaded eagerly because they apply to nearly every quant task (in addition to `python-engineer`'s proactive cross-refs):
+
+- `provider:default/financial/futures-etf-translation.md` — leveraged ETF → micro futures (MNQ/MES) sizing, P/L mapping, DCA mechanics
+- `provider:default/financial/numeric-precision-strategy.md` — `Decimal` vs integer minor-units vs float tradeoffs across layers
+- `provider:default/resilience-patterns.md` — retry/idempotency, dedup, circuit breakers, domain exceptions; broker APIs and market data feeds need defensive boundaries
+- `provider:default/api-design.md` — request/response shape discipline, versioning, error envelopes; relevant when wrapping vendor broker APIs
+
+## Cross-Refs
+
+Load on demand when the work touches the listed area:
+
+### Financial domain
+- `provider:default/financial/applications.md` — calculation safety invariants, zero-divisor guards, idempotency patterns; load for fee, sizing, or risk calc work
+- `provider:default/financial/order-book-pricing.md` — modeling fills, slippage, bid/ask mechanics in the backtester
+- `provider:default/financial/market-calendars.md` — trading-day arithmetic, session boundaries, holiday handling
+- `provider:default/financial/futures-tick-rounding.md` — tick-size rounding for futures order prices
+- `provider:default/financial/tradestation-api.md` — TradeStation WebAPI v3 quirks: response shapes, error envelopes, sentinel values
+
+### Testing
+- `provider:default/testing/testing-patterns.md` — pytest isolation, module-level singleton pitfalls, mock coupling, cross-test leakage (also referenced by `python-engineer`)

--- a/claude/commands/set-persona/react-frontend.md
+++ b/claude/commands/set-persona/react-frontend.md
@@ -40,10 +40,11 @@
 These learning files contain full recipes, code examples, and edge cases for each sub-domain. Load when working in the specific area:
 
 - `provider:default/code-quality-instincts.md` — Universal code quality instincts (no duplication, single source of truth, port intent)
-- `provider:default/frontend/react-patterns.md` — React 19 setState rules, hydration gating, lazy initializers, hook extraction, two-tier design, modals, polling
+- `provider:default/frontend/react-state-effects.md` — React 19 setState rules, hydration gating, lazy initializers, render-time sync
+- `provider:default/frontend/react-hooks-and-ui.md` — hook extraction, two-tier design, modals, polling, page decomposition
 - `provider:default/reactive-data-patterns.md` — Reactive refresh, client-side expiration tracking, silent fetch pattern
 - `provider:default/frontend/nextjs.md` — Next.js 16 proxy.ts, dynamic params, Turbopack gotchas, rate limiter wiring
 - `provider:default/frontend/accessibility-patterns.md` — ARIA attribute patterns with code examples
 - `provider:default/frontend/ui-patterns.md` — Tailwind tooltips, SVG gotchas, design token centralization
-- `provider:default/testing-patterns.md` — Vitest/RTL stack, vi.mock hoisting, route handler test patterns, shared test helpers, jsdom gotchas
-- `provider:default/playwright-patterns.md` — 17 testing patterns covering selectors, state, modals, assertions
+- `provider:default/testing/testing-patterns.md` — Vitest/RTL stack, vi.mock hoisting, route handler test patterns, shared test helpers, jsdom gotchas
+- `provider:default/testing/playwright-patterns.md` — 17 testing patterns covering selectors, state, modals, assertions

--- a/claude/commands/set-persona/reviewer.md
+++ b/claude/commands/set-persona/reviewer.md
@@ -21,4 +21,4 @@ Base persona for all code review workflows. Provides universal review instincts 
 ## Proactive loads
 - `provider:default/code-quality-instincts.md`
 - `provider:default/process-conventions.md`
-- `provider:default/code-review-methodology.md`
+- `provider:default/review-conventions.md`

--- a/claude/commands/set-persona/typescript-devops.md
+++ b/claude/commands/set-persona/typescript-devops.md
@@ -21,4 +21,6 @@
 
 Load when working in the specific area:
 - `provider:personal/vercel-deployment.md` — Cron job limits, Vercel Postgres (Neon HTTP driver), nullable column comparisons (personal provider only)
-- `provider:default/gitlab-ci-cd.md` — GitLab CI/CD patterns, debugging, GitHub Actions and GitLab CI tripwires, Docker build stage sharing
+- `provider:default/cicd/gitlab-ci-patterns.md` — GitLab CI patterns: YAML anchors, Maven, BuildKit, artifact scoping
+- `provider:default/cicd/gitlab.md` — glab CLI debugging, MR API endpoints, pipeline stage splitting
+- `provider:default/cicd/patterns.md` — GitHub Actions tripwires, composite actions, Docker build/push stage sharing

--- a/claude/commands/set-persona/xrpl-typescript-fullstack.md
+++ b/claude/commands/set-persona/xrpl-typescript-fullstack.md
@@ -46,7 +46,8 @@ Buffer/TextEncoder, shared encoding fixtures, URI XSS — see `provider:default/
 ## Cross-Refs
 
 Load when working in the specific area:
-- `provider:default/frontend/react-patterns.md` — React 19 setState rules, hydration gating, lazy initializers, hook extraction, two-tier design, modals, polling
+- `provider:default/frontend/react-state-effects.md` — React 19 setState rules, hydration gating, lazy initializers, render-time sync
+- `provider:default/frontend/react-hooks-and-ui.md` — hook extraction, two-tier design, modals, polling, page decomposition
 - `provider:default/frontend/nextjs.md` — Next.js 16 proxy.ts, dynamic params, Turbopack gotchas, rate limiter wiring
 - `provider:default/xrpl/patterns.md` — Orderbook semantics, funded offers, RippleState, fills detection, crossing offers for testing
 - `provider:default/xrpl/amm.md` — AMM constant-product formulas, CLOB+AMM interleaved fill estimation

--- a/claude/learnings/CLAUDE.md
+++ b/claude/learnings/CLAUDE.md
@@ -30,8 +30,9 @@ If `docs/learnings/CLAUDE.md` exists in the current project, read it for repo-lo
 - `vercel-deployment.md` — Vercel: cron job limits, Postgres (Neon), environment variables
 - `kubernetes-helm-patterns.md` — Helm: bootstrapping apps from templates, prometheusrule boilerplate gotcha
 - `nginx-patterns.md` — nginx: alias+try_files SPA routing, add_header inheritance in named locations, Vite base path, proxy_pass trailing slash
-- `docker-compose-patterns.md` — Docker Compose: per-service `logging:`, plugin form, EBUSY on file bind-mounts, path-migration mounts
-- `terraform-patterns.md` — Terraform: fallback-source `count` gating, `templatefile()` secret exposure, `lifecycle { ignore_changes }` recovery
+- `docker-compose-patterns.md` — Docker Compose: per-service `logging:`, plugin form, EBUSY on file bind-mounts, path-migration mounts, bind-mount perm inheritance
+- `docker-image-patterns.md` — Docker images: `repo:tag` vs `repo-<hash>` grammar, WORKDIR vs relative paths, multi-service `docker run -d`, disk reclaim semantics
+- `terraform-patterns.md` — Terraform: fallback-source `count` gating, `templatefile()` secret exposure, `lifecycle { ignore_changes }` recovery, `prevent_destroy` literal constraint + Path A/B/C tradeoff, ephemeral-env teardown script, agent-driven IaC account boundary, PR verification ladder
 
 ## Security
 

--- a/claude/learnings/api-design.md
+++ b/claude/learnings/api-design.md
@@ -133,6 +133,17 @@ logger.error("API error on %s: %s | full record: %s", record["id"], record["Erro
 
 Default to full-record logging on failure paths. Cost is bytes; value is debug-time when remote-side reasons aren't predictable in advance.
 
+## Single-resource APIs can return 200 with error envelope replacing the payload
+
+Sibling to the batch case above, at envelope level. A vendor may return `200 OK` with `{"Error": "Failed", "Message": "..."}` *instead of* the expected `{"Bars": [...]}` payload — no expected field at all. `data.get("Bars") or []` collapses to "empty data" and validators never see the error; `raise_for_status()` doesn't catch this since HTTP is 200. Common with entitlement gates and rate limits.
+
+Validate shape positively before defaulting:
+
+```python
+if "Error" in data or "Bars" not in data:
+    raise RuntimeError(f"vendor error: {data.get('Message', data)}")
+```
+
 ## Adapter and client layers can have separate validation tiers
 
 When wrapping a vendor API behind an adapter (BrokerAdapter → VendorClient), the two layers often enforce different symbol/input regexes — adapter validation is typically stricter than client validation because each layer covers a different surface. The client may accept symbol form X for data endpoints while the adapter rejects X for order placement, both correctly mirroring vendor semantics (e.g., continuous futures symbols are queryable but not orderable). Before concluding "the wrapper rejects X," trace which call path the validation actually runs on — single-regex assumptions miss this layered pattern.

--- a/claude/learnings/bash-patterns.md
+++ b/claude/learnings/bash-patterns.md
@@ -328,6 +328,49 @@ matches=$(rg --no-config "$PATTERN" "$SEARCH_DIR" || true)              # || tru
 
 Same shape applies to `grep` (1=no-match, 2=error) and `diff` (1=different, 2=error). Don't try to remove `|| true` — eliminate what it could mask.
 
+## Race-safe leaf-dir creation: `mkdir -p parent && mkdir leaf`
+
+The TOCTOU pattern `[ -e "$DIR" ] || mkdir -p "$DIR"` lets parallel callers both pass the existence check and both succeed via `-p` idempotence — they then race on the contents. Atomic alternative:
+
+```bash
+mkdir -p "$(dirname "$LEAF")"   # parent — idempotent, race-safe
+mkdir "$LEAF"                    # leaf  — fails on the loser of any race
+```
+
+`mkdir` (no `-p`) on the leaf is the atomic primitive: either you created it or you didn't. Use this whenever the leaf dir's *creation event* matters (session dirs, run dirs, lock dirs). When parents are guaranteed to exist, the second line alone is enough.
+
+## `done <<< "$VAR"` over `done < <(cmd)` keeps `set -e` honest
+
+Process substitution `< <(cmd)` runs `cmd` in a subshell whose exit status is **invisible** to the outer `set -e` and to `|| { ... }` wrappers — a corrupted-input failure produces an empty stream, the loop body silently no-ops, and the script exits 0. Capture first, then iterate via here-string:
+
+```bash
+ITEMS=$(jq -r '.eligible[].number' "$MANIFEST") \
+    || { echo "ERROR: failed to parse $MANIFEST" >&2; exit 1; }
+
+while IFS= read -r item; do
+    [ -n "$item" ] || continue   # here-strings can emit a trailing empty line
+    ...
+done <<< "$ITEMS"
+```
+
+Tradeoff: loses streaming (whole output materialized in memory). Use process-substitution form when the input is unbounded (logs, large query results) and you've explicitly decided silent-empty-on-failure is acceptable. For bounded scriptable input — manifests, config dumps, grep results that drive control flow — capture-then-iterate is the safer default.
+
+## `cmd | tail -N` doesn't emit until EOF — hides hung processes
+
+Piping a long-running command through `tail -N` makes the output appear silent until `cmd` exits — `tail` reads stdin and only prints the last N lines at EOF. A hung process produces zero-byte output indistinguishable from a slow one; you'll watch a 0-line file for minutes thinking nothing's happening.
+
+Symptom: `wc -l output.log` returns 0 while `ps` shows the process running and consuming CPU.
+
+Fixes (pick by intent):
+
+```bash
+cmd > out.log 2>&1                      # write file directly; tail -f to watch live
+cmd 2>&1 | grep --line-buffered KEY     # streaming filter; grep -m1 for first match
+cmd 2>&1 | tee out.log | tail -20       # tee splits, file lives, tail still buffers
+```
+
+The `tee out.log | tail -N` form is the safest default: you preserve the live log for `tail -f` debugging and still get the post-completion summary.
+
 ## Cross-Refs
 
 - `~/.claude/learnings/claude-code/platform-permissions.md` — Bash permission prefix matching gotchas (chaining, subshells, quoted strings, tilde expansion — complementary permission-system angle)

--- a/claude/learnings/bash-patterns.md
+++ b/claude/learnings/bash-patterns.md
@@ -1,5 +1,5 @@
 Shell scripting gotchas and recipes covering `set -euo pipefail` traps, `gh api` query patterns, shared test helpers, and zsh compatibility.
-- **Keywords:** set -e, pipefail, set -u, unbound variable, command substitution, gh api, zsh globbing, rsync --delete, lib.sh, empty array expansion, teardown
+- **Keywords:** set -e, pipefail, set -u, unbound variable, command substitution, gh api, zsh globbing, rsync --delete, lib.sh, empty array expansion, teardown, heredoc, git commit -F, multi-line commit message
 - **Related:** ~/.claude/learnings/claude-code/platform-permissions.md, ~/.claude/learnings/git-patterns.md
 
 ---
@@ -313,6 +313,22 @@ docker run ... -v "/tmp/wrapper.py:/workspace/wrapper.py" image python /workspac
 ```
 
 **Single-quoted delimiter (`<<'EOF'`) is critical** — unquoted `<<EOF` performs `$VAR`/`$(...)` interpolation, silently mangling `$1`, `$@`, `${...}` patterns inside the body.
+
+## `git commit -F - <<'EOF'` for multi-line commit messages
+
+`git commit -m "subject\n\nbody"` triggers a permission prompt (quoted string) and `\n` doesn't expand — git takes the literal `\n` as part of the subject line. Pipe a single-quoted heredoc to stdin instead:
+
+```bash
+git commit -F - <<'EOF'
+chore: subject line
+
+Body paragraph with `code`, "quotes", and $sigils all safe inside <<'EOF'.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+```
+
+Single-quoted `<<'EOF'` prevents `$VAR`/`$(...)` expansion in the body — matters when the commit mentions shell sigils (`$1`, `${...}`, command substitutions). Same shape works for `gh pr edit --body-file -` when you want to skip the temp-file step.
 
 ## `ripgrep` exit code 1 = "no matches"; pair `|| true` with preflight error elimination
 

--- a/claude/learnings/cicd/patterns.md
+++ b/claude/learnings/cicd/patterns.md
@@ -38,6 +38,14 @@ When CI changes can't be tested locally, push intermediate commits to validate t
 - Set job timeouts: 5 min for fast jobs, 15 min for E2E
 - Diagnosing failures: `gh run view <RUN_ID> --job <JOB_ID> --log-failed` — pipe through `tail -80`
 
+## Stale CI Checks After PR Base Change
+
+PR-targeted workflows filtered by `on.pull_request.branches: [main]` don't re-trigger when a PR's base is repointed to a different branch — the filter applies to the *new* base, so subsequent commits skip the workflow and the prior failed check stays red.
+
+Clear it with `gh run rerun <run-id> --failed`. The rerun executes the same job, but runtime API calls (e.g., `gh api repos/.../pulls/N/files`) return the PR's *current* state — so a check that failed against the old base often passes against the new one without any code changes.
+
+Diagnosis: compare the failed run's `headSha` and `createdAt` against `gh pr view <N> --json updatedAt,baseRefName`. If the PR was edited (base changed) after the run, the failure reflects a prior state.
+
 ## Use `docker login --password-stdin` instead of `-p` flag
 
 Passing passwords via `docker login -p` exposes credentials in process listings (`ps aux`). Use `echo "$SECRET" | docker login --password-stdin` instead. This applies to any CI/CD pipeline or script that authenticates to a container registry.

--- a/claude/learnings/claude-authoring/claude-md.md
+++ b/claude/learnings/claude-authoring/claude-md.md
@@ -1,28 +1,30 @@
-Core patterns for writing effective CLAUDE.md files: conditional @ references, subdirectory criteria, documenting relationships, pointer pattern, single source of truth, and stating conclusions.
-- **Keywords:** CLAUDE.md, @ reference, eager load, subdirectory criteria, symlink, navigational hub, relationships, pointers, single source of truth
-- **Related:** none
+Core patterns for writing effective CLAUDE.md files: lazy sub-CLAUDE.md index (plain paths, not `@`), subdirectory criteria, documenting relationships, pointer pattern, single source of truth, and stating conclusions.
+- **Keywords:** CLAUDE.md, @ reference, eager load, lazy reference, plain path index, subdirectory criteria, symlink, navigational hub, relationships, pointers, single source of truth
+- **Related:** ~/.claude/learnings/claude-code/explore-repo.md
 
 ---
 
-## Conditional `@` Reference Pattern
+## Subdirectory CLAUDE.md: Lazy Plain-Path Index, Not `@`
 
 **Problem:** Putting all context inline in root CLAUDE.md bloats token usage for every agent invocation, even when the agent only needs context for one subsystem.
 
-**Solution:** Use conditional `@` references in root CLAUDE.md that point to subdirectory CLAUDE.md files. Agents auto-load CLAUDE.md files when they enter directories directly, so the subdirectory files serve double duty:
-1. **Top-down discovery** — an agent reading root CLAUDE.md sees the reference and can load it if relevant
-2. **Bottom-up auto-loading** — an agent that enters the directory directly gets the context automatically
+**Solution:** Decompose into subdirectory CLAUDE.md files and reference them from root as a **plain-path index** — not `@`-references.
 
-**Format in root CLAUDE.md:**
 ```markdown
 ## Context-Specific Guides
 
-@database/CLAUDE.md - Migration conventions and schema design
-@server/orders/CLAUDE.md - Order processing architecture and state machine
-@server/billing/CLAUDE.md - Payment and settlement flows
-@test/utils/CLAUDE.md - Test infrastructure and shared helpers
+Read on-demand when working in the relevant subdirectory:
+
+- `database/CLAUDE.md` — Migration conventions and schema design
+- `server/orders/CLAUDE.md` — Order processing architecture and state machine
+- `test/utils/CLAUDE.md` — Test infrastructure and shared helpers
 ```
 
-**Key insight:** `@` references eagerly load the referenced file's content into every conversation. This makes root CLAUDE.md a navigational hub, but each `@` reference has a real token cost. Use this pattern to organize context into focused subdirectory files — the agent pays only for the subset relevant to its task when entering a directory directly, rather than loading everything from a monolithic root file.
+**Why not `@`:** `@` references eagerly load the referenced file into **every** session's context, regardless of task. The "agent pays only for the subset relevant" framing is wrong for sub-CLAUDE.md — `@` collapses subdirectory files back into the always-on root payload.
+
+**Why lazy works:** CLAUDE.md auto-discovery gives you the bottom-up benefit *for free* — an agent entering `server/orders/` auto-loads `server/orders/CLAUDE.md` whether or not root referenced it. The plain-path index in root only adds top-down discoverability (agent sees the entry, reads on demand) without paying the eager-load cost.
+
+**When `@` IS appropriate:** Content that genuinely belongs in every session — global guidelines, shared conventions, the project's core rules. Reserve `@` for "load every time"; use plain paths for "load when relevant." See also: `~/.claude/learnings/claude-code/explore-repo.md` § "CLAUDE.md Should Not `@`-Include Scan Artifacts" for the same principle applied to scan output.
 
 ## Subdirectory CLAUDE.md Criteria
 
@@ -150,4 +152,4 @@ The breadcrumb bridges the gap: no token cost beyond ~25 tokens, no automatic be
 
 ## Cross-Refs
 
-No cross-cluster references.
+- `~/.claude/learnings/claude-code/explore-repo.md` § "CLAUDE.md Should Not `@`-Include Scan Artifacts" — same lazy-vs-eager principle applied to scan output

--- a/claude/learnings/claude-authoring/personas.md
+++ b/claude/learnings/claude-authoring/personas.md
@@ -145,6 +145,26 @@ When agents operate without an operator setting a persona (e.g., sweep:work-item
 
 The auto-detected persona improves both learnings search (narrows cluster matching) and work quality (applies domain-specific priorities and gotchas). Log the detection: `🎭 Persona: <name>` or `🎭 No persona match — proceeding without`. Include persona in status.md for director visibility.
 
+## Persona Proactive-Load Paths Decay Silently
+
+The set-persona skill warns-but-proceeds when a `## Proactive loads` or `## Proactive Cross-Refs` entry resolves to a missing file. Stale paths sit in personas indefinitely without breaking activation — only an attentive operator on activation notices the warning. Two prevention rules:
+
+1. **On rename/move:** `grep -rln <old-filename> ~/.claude/commands/set-persona/ ~/.claude/learnings/` immediately. Persona refs use the `provider:<name>/path` slug, so grep the bare filename to catch both slug and absolute-path forms.
+2. **On persona activation:** if the proactive-load count from the announcement doesn't match the persona's declared list, investigate before relying on the persona's gotcha coverage.
+3. **Periodic batch audit:** Rules 1–2 are prophylactic; refs accumulate when past reorgs skipped them. Enumerate every slug and test existence:
+
+   ```bash
+   grep -rho -E 'provider:default/[A-Za-z0-9._/-]+\.md' ~/.claude/commands/set-persona/ \
+     | sort -u | while read ref; do
+         path=~/.claude/learnings/${ref#provider:default/}
+         test -e $path || echo MISSING $ref
+       done
+   ```
+
+   Triage broken refs into three fix shapes — **path move** (swap path only), **rename** (find replacement via `head -3` on cluster candidates; line-1 descriptions persist across renames and often restate the original ref's description verbatim), or **split** (one file → many; expand single ref into N, partitioning the original description by new-file scope — the description IS the partition guide).
+
+Sibling pattern to `learnings-organization.md`'s cross-ref staleness, but the persona surface is distinct: cross-refs are read on-demand (failure visible at use time), proactive-loads are read at activation (failure visible only in the activation announcement, then forgotten).
+
 ## Cross-Refs
 
-No cross-cluster references.
+- `~/.claude/learnings/claude-authoring/learnings-organization.md` — cross-ref staleness in learnings (sibling concern, different surface)

--- a/claude/learnings/claude-authoring/skill-design.md
+++ b/claude/learnings/claude-authoring/skill-design.md
@@ -1,5 +1,5 @@
 Skill design fundamentals — composition, creation heuristics, responsibility boundaries, and validation patterns.
-- **Keywords:** skill design, compose, AskUserQuestion, skill responsibility, stateful mode, gap vs inconsistency, exploration skill, portable, bash commands, validation, intake gate, triage, open contribution, $ARGUMENTS, disable-model-invocation, irreversible, template compliance, prompt template, body discipline, default skip, conditional step, gate phrasing
+- **Keywords:** skill design, compose, AskUserQuestion, skill responsibility, stateful mode, gap vs inconsistency, exploration skill, portable, bash commands, validation, intake gate, triage, open contribution, $ARGUMENTS, disable-model-invocation, irreversible, template compliance, prompt template, body discipline, default skip, conditional step, gate phrasing, section descriptors, output format, numeric caps, table skeletons, downstream consumers, section headings as api, preview field
 - **Related:** none
 
 ---
@@ -318,6 +318,25 @@ Post a summary covering X, Y, Z. If there's nothing to report, skip.
 ```
 
 The gate phrasing ("If zero, stop — do not draft, do not post") prevents the silent drafting-then-cutting loop. Applies to any optional output (summary comments, retro messages, status updates, completion reports).
+
+## Section Descriptors Prime Output Format
+
+A section descriptor like `[1-2 paragraphs: ...]` or `For each module: name, purpose, location, entry point, ...` reads to the agent as "produce a paragraph" or "produce a prose list." Even when global FORMAT rules say "prefer tables," agents follow the local structural cue. Sibling of "Template Examples Are the Primary Compliance Mechanism" — same principle, different artifact (section descriptor vs. example placeholder).
+
+**Rule:** replace prose-shaped descriptors with structures that can't be expanded into prose:
+- **Table skeletons** for parallel per-item data: `| Module | Location | Purpose | Entry point | Depends on |` beats "For each module: name, location, purpose, ..."
+- **Required diagrams** for flows / relationships / state: "ASCII flow diagram (trigger → steps → outcome)" beats "trace the workflow."
+- **Numeric caps** on prose that must remain: `≤3 sentences`, `≤7 bullets`. Caps are checkable across reps; "concise" / "prefer" degrade.
+
+## AskUserQuestion Previews for Directive Wording
+
+When asking the operator to pick between variants of how a rule will be worded (strictness levels, scope, phrasing), put the actual proposed text in each option's `preview` field. The operator picks the wording they'll live with, not their interpretation of a description. Descriptions explain the trade-off; previews show the exact text that lands in the skill. Especially useful when the difference between options is subtle phrasing rather than a visible artifact.
+
+## Section Headings Are an API for Downstream Phases
+
+When a skill has downstream consumers — synthesis phases that grep for section counts, sub-skills (`/explore-repo:brief`) that read named sections, validators that parse heading anchors — the section headings are a contract. Restructure content inside headings freely; rename or remove a heading and the consumer silently misses data.
+
+**Rule:** before restructuring a skill's output format, grep the skill (and any subskills under the same directory) for the section names. Preserve referenced headings; reorganize only the bodies. If a heading rename is genuinely needed, update the consumer in the same edit.
 
 ## Cross-Refs
 

--- a/claude/learnings/claude-authoring/skill-references-and-loading.md
+++ b/claude/learnings/claude-authoring/skill-references-and-loading.md
@@ -105,6 +105,15 @@ When skill A's reference file says "same criteria as skill B's reference file," 
 
 When a reference file is read by every invocation of a skill (not conditionally), use `@` eager loading instead of a conditional read instruction. The context cost is identical — the agent reads it either way — but eager loading saves a tool call and guarantees availability. Reserve conditional reads (`read X if mode is Y`) for files genuinely needed only in some code paths.
 
+## Eager-Pointer + Lazy-Index for Sprawling Helper Directories
+
+When a `skill-references/` subtree mixes executables, templates, and stubs (~10+ files across multiple typologies), agents reach for ad-hoc Bash instead of finding the right helper. Fix:
+
+- **Lazy `INDEX.md`** at the directory root listing each helper with usage one-liner + the typology table (executable wrapper / template / platform stub).
+- **Eager one-line pointer** in `~/.claude/CLAUDE.md` (or the skill that touches the dir) cueing "consult `<dir>/INDEX.md` before complex Bash."
+
+Pointer costs ~150 tokens session-start; index loads only when triggered. This pattern beats memory entries that encode *negative* rules ("don't `tail`/`cat` directly") because the index delivers the *positive* answer at the moment of need — and a flat one-page reference scales better than a growing list of "don't do X" memories that only fire if the agent already knows to look.
+
 ## `!` Preprocessing Is SKILL.md-Only (Empirically Confirmed)
 
 `!` preprocessing runs when the CLI loads a SKILL.md via the Skill tool — it substitutes `!`cmd`` with stdout before the agent sees the file. Files read at runtime via the Read tool get raw text — `!` directives appear as literal strings. Implications: (1) shared reference files like `request-interaction-base.md` can contain `!`cat` includes and they'll resolve when the skill loads them via `@`, but NOT when an agent reads them with the Read tool mid-session. (2) Subagent prompt templates assembled at runtime can't benefit from `!` — use explicit `.sh` filenames for the subagent to `cat` at execution time. (3) `@`-reference in SKILL.md enables `!` for templates but forces always-on loading — a tradeoff between preprocessing and context cost.

--- a/claude/learnings/claude-code/agent-definitions.md
+++ b/claude/learnings/claude-code/agent-definitions.md
@@ -55,6 +55,24 @@ skills:
 ```
 The agent's markdown body is the system prompt; skills provide domain knowledge preloaded into context. This is the **inverse** of `context: fork` — here the agent controls the system prompt, not the skill. Use when the agent needs domain knowledge from multiple skills without the overhead of discovering them.
 
+## When to Fold an Agent Into a Persona
+
+If an agent's value is *applying a lens* — priority weighting, gotcha awareness, tradeoff calibration, review focus — rather than *executing isolated work* — multi-step research, parallel exploration, context-heavy reading — the agent is overhead. Promote it to a persona.
+
+| Signal | Verdict |
+|--------|---------|
+| Always invoked as "review this with X mindset" / "think about this as Y" | Fold to persona |
+| Invocations look like "go do Z autonomously, return a report" | Keep as agent |
+| Value is judgment per token of output | Fold to persona |
+| Value is parallelism, isolation, or context budget protection | Keep as agent |
+| Body reads like a system prompt of preferences, not a task spec | Fold to persona |
+
+Personas pay near-zero structural cost (they're a lens loaded into the main loop) where agents pay isolation overhead (separate context, tool plumbing, return-value coordination). When the work was always happening inline anyway, the agent's isolation buys nothing.
+
+Composition lets you fold multiple specialist agents into one fused persona without losing structure — the `## Extends: base-persona` pattern preserves the inheritance shape (e.g., `python-quant-dev` extends `python-engineer`; `java-fintech` extends `fintech-ledger-engineer` and `java-backend`). Two formerly-separate agent personalities can live in one persona file when the activation triggers overlap heavily.
+
+**Provenance footprints to clean on fold:** persona files synthesized from former agents often carry `## Delegation hints` sections or "delegate to the agents for isolated deep dives" header fragments. Once the agents are gone, those are stale refs — strip them during the fold or in a follow-up pass.
+
 ## Cross-Refs
 
 No cross-cluster references.

--- a/claude/learnings/claude-code/multi-agent/director/failure-modes.md
+++ b/claude/learnings/claude-code/multi-agent/director/failure-modes.md
@@ -32,14 +32,20 @@ The recovery pattern: **don't rerun the same `let-it-rip.sh`**. Re-invoke the sw
 - Worktrees from the prior sweep persist — new artifacts can reference them via `worktree-cases.txt` without re-creating
 - Per-PR `directives.md` written at the run-dir level (e.g., `Fixes #N` body keyword) carry over only if you keep using the same address run-dir; for fresh address artifacts, copy the directive over
 
-Symptoms that say "you hit the storm": `context_used_tokens: 0` + `duration_seconds < 60` + `is_error: true` in `live.md`'s `completed` event, on multiple PRs in the same cycle. Distinguishes from genuine rate limits (which produce `rate_limit` events and `.rate-limited` sentinel).
+Symptoms that say "you hit the storm": `context_used_tokens: 0` + `duration_seconds < 60` + `"is_error":true` in `output.log`'s `completed` event, on multiple PRs in the same cycle. Distinguishes from genuine rate limits (which produce `rate_limit` events and `.rate-limited` sentinel).
+
+**Diagnosis — prompt-free path:**
+```
+bash ~/.claude/skill-references/sweep-status-summary.sh <RUN_DIR> --logs 30
+```
+Tails each item's `output.log` (the stream-json record) — contains `rate_limit_event`, `is_error`, `context_used_tokens`. Allowlisted under `Bash(bash ~/.claude/skill-references/**)`. Do NOT use `tail`/`cat` on `live.md` or `output.log` directly — those aren't allowlisted and prompt the operator on every call.
 
 ## 30-Second Exit Diagnosis: raw.jsonl Turn-Text First
 
-A `claude -p` session exiting in <60s has multiple distinct failure modes that look identical at the `live.md` event-tag level. **Always read `raw.jsonl` turn text before hypothesizing the cause** — the `live.md` synthesis can mislead.
+A `claude -p` session exiting in <60s has multiple distinct failure modes that look identical at the event-tag level. **Always read `raw.jsonl` turn text before hypothesizing the cause** — `live.md`'s synthesis can mislead.
 
-| Cause | duration | is_error | context_tokens | live.md tag | raw.jsonl turn_text reveals |
-|-------|----------|----------|---------------|-------------|----------------------------|
+| Cause | duration | is_error | context_tokens | event tag | raw.jsonl turn_text reveals |
+|-------|----------|----------|---------------|-----------|----------------------------|
 | Genuine 5h rate limit | <60s | false | 0 | `rate_limit` | API blocked turn 1 |
 | Compound-mode storm | <60s | **true** | 0 | `completed is_error: true` | session never ran |
 | **Resume-cache short-circuit** | ~30s | false | ~40k | `rate_limit` (informational) | *"already posted, nothing to do"* |
@@ -48,9 +54,10 @@ A `claude -p` session exiting in <60s has multiple distinct failure modes that l
 The **resume-cache short-circuit** is the trap: `claude -p --resume <session_id>` carries cached context from prior cycles, so the model "remembers" cycle N-1's `milestone: posted` and self-skips without reading directives or re-checking watermarks. The `rate_limit_event` in stream-json is informational (`status: allowed`) and unrelated to the bail-out — but its presence in `live.md` makes it look causal.
 
 **Diagnostic gate (pre-action):**
-1. `cat raw.jsonl | jq -c '{type, turn_text: .message.content[0].text, result}'`
-2. If turn_text contains "already posted", "complete", "nothing to do" → resume-cache short-circuit, **not rate limit**
-3. Recovery: fresh-timestamp restart (same as compound storm), since `claude --resume` keeps reading the same `session_id` even with directives present
+1. **First pass — allowlisted summary:** `bash ~/.claude/skill-references/sweep-status-summary.sh <RUN_DIR> --logs 60`. Greps the output.log dump for `rate_limit_event`, `"is_error":true`, `"already posted"`, `"complete"`, `"nothing to do"`. Often resolves the diagnosis without going deeper.
+2. **Deep pass — turn text:** if step 1 is ambiguous, read `raw.jsonl` directly: `cat raw.jsonl | jq -c '{type, turn_text: .message.content[0].text, result}'`. May prompt for permission if `Bash(cat:*)` isn't allowlisted — accept the prompt only when step 1 was inconclusive.
+3. If turn_text contains "already posted", "complete", "nothing to do" → resume-cache short-circuit, **not rate limit**.
+4. Recovery: fresh-timestamp restart (same as compound storm), since `claude --resume` keeps reading the same `session_id` even with directives present.
 
 **Anti-pattern:** jumping to the rate-limit hypothesis based on the `live.md` `rate_limit` tag without reading turn text. One real session lost ~4 hours waiting for a 5h quota reset that wasn't actually blocking.
 

--- a/claude/learnings/claude-code/multi-agent/director/observability.md
+++ b/claude/learnings/claude-code/multi-agent/director/observability.md
@@ -28,9 +28,18 @@ Active sessions that take long are valid; silence is the failure signal. Use `li
 
 `claude -p --output-format stream-json` fails with "Error: When using --print, --output-format=stream-json requires --verbose." The error goes to stderr and the session exits immediately — `status.md` stays at `launching`, output log is empty, and the runner reports success (exit 0). Use `claude -p --verbose --output-format stream-json`.
 
-## Use `sweep-status-summary.sh` for Status Checks
+## Use `sweep-status-summary.sh` for Status Checks AND Log Tailing
 
-`~/.claude/skill-references/sweep-status-summary.sh` exists for reading run directory status. Use it instead of ad-hoc Bash `for` loops or `cat` commands, which trigger permission prompts (they don't match single-command patterns like `Bash(gh pr view:*)`). The script matches `Bash(bash ~/.claude/skill-references/**)` and outputs a formatted per-item section dump that the director parses into the monitoring table.
+`~/.claude/skill-references/sweep-status-summary.sh` exists for reading run directory status. Use it instead of ad-hoc Bash `for` loops or `cat`/`tail` commands, which trigger permission prompts (they don't match single-command patterns like `Bash(gh pr view:*)`). The script matches `Bash(bash ~/.claude/skill-references/**)` and outputs a formatted per-item section dump that the director parses into the monitoring table.
+
+**Three modes — pick by what you need:**
+| Need | Invocation |
+|------|-----------|
+| Monitoring table (status + state) | `sweep-status-summary.sh <RUN_DIR>` |
+| Log tailing (per-PR `output.log`, last N lines — stream-json with `rate_limit_event`, `is_error`, tool calls) | `sweep-status-summary.sh <RUN_DIR> --logs N` |
+| Retro (also dump `results.md` + `learnings.md`) | `sweep-status-summary.sh <RUN_DIR> --retro` |
+
+The `--logs` mode is the prompt-free path for diagnosing rate-limit storms, resume-cache short-circuits, and other failure modes that require reading per-session output. Reach for it before `tail`/`cat` on `live.md`/`output.log`/`raw.jsonl`. Cross-ref: `failure-modes.md` "30-Second Exit Diagnosis" walks through the log-grep workflow.
 
 ## Reviewer Convergence-Cycle Skips `results.md` Append
 

--- a/claude/learnings/claude-code/multi-agent/director/process-and-meta.md
+++ b/claude/learnings/claude-code/multi-agent/director/process-and-meta.md
@@ -75,3 +75,9 @@ Adjustment: weight clarify higher for operator-authored issues even when all thr
 When the operator names a subset for a re-sweep ("re-run on #101 and #103") AND signals suggest fresh activity on nearby items (recent replies, active back-and-forth on related issues, timestamps within the last ~10 minutes), surface the gap BEFORE executing: *"I notice #100 was also replied to just now — include it?"*
 
 Scope typos and omissions are common in fast conversations. The director has more signal than the operator in the moment (last-comment timestamps from earlier fetches, session history). Proactively verify rather than processing the literal request and then discovering the gap mid-cycle. One extra line pre-launch beats one aborted session and one operator correction.
+
+## Review Persona ≠ Addresser Persona — Don't Auto-Propagate at Initial Handoff
+
+Review personas (architecture, correctness, security, etc.) are the *reviewer's* finding lens. The addresser needs the *engineering* lens that matches the changed domain — often a different shape. Resist writing a director directive setting `addresser persona = first review persona` just because the review signal is fresh and uncertainty feels uncomfortable. When the assessment-time persona match isn't confident, leave the addresser at `none` and let the addresser-prompt's per-finding judgment carry the work. If cycle-1 re-review reveals weak/generic responses, *then* write a persona directive for cycle-2.
+
+Distinct from the matrix's "Persona propagation — carry forward persona from prior runs": that rule covers *subsequent* runs on the same item. This rule covers the *initial* review→address handoff. Empirical: compound session on PRs #197/#198 left both addressers at `none`; both produced clean implementations (12 of 15 findings auto-implemented, 1 well-reasoned partial, 2 explicit no-change with context) — confirming the no-directive default earns its keep.

--- a/claude/learnings/claude-code/multi-agent/director/watermarks-and-skip.md
+++ b/claude/learnings/claude-code/multi-agent/director/watermarks-and-skip.md
@@ -49,3 +49,28 @@ The summary-only directive pattern is well-known for cycle-0 reviews where `find
 **Detection:** every review cycle's `results.md` should be checked for `New Findings > New Inline Comments`, not just first-pass. If the differential is non-zero on a re-review, write the directive **immediately** — before launching the next address cycle — instead of relying on the cycle to surface the miss.
 
 **Director rule:** read each completed review's `results.md` proactively on runner-completion notification. Don't defer body-only-finding detection to the address session — its watermark/classification logic can't see body content.
+
+## Status.md Reset Destroys Watermark — Addresser Directives-Only Short-Circuit
+
+Runner pre-flight overwrites `status.md` to `milestone: launching` between cycles, discarding the prior cycle's `last_addressed_sha` / `last_comment_id`. The next addresser session reads the launching stub, finds no watermark, and early-exits when `directives.md` shows all existing directives satisfied — never reaching the step that fetches current comment IDs and compares. Reply-only exit paths (the addresser posts a thread reply but no commit) also often skip writing the next `results.md` round, so director observability stays blind to what actually happened.
+
+| Symptom | Value |
+|---------|-------|
+| `duration_seconds` | <60 |
+| `is_error` | false |
+| `context_used_tokens` | 40k–80k |
+| `status.md` | `milestone: launching` only — no `last_*` fields |
+| `results.md` | unchanged from prior cycle |
+| GitHub comments | new IDs above prior `last_comment_id` |
+| Agent final text | variant of *"no new directives, work complete"* |
+
+Distinct from the **resume-cache short-circuit** in `failure-modes.md` (which carries `rate_limit_event` informational + cached cycle-N-1 context) and from **legitimate watermark skip** (which writes `milestone: skipped`). Detection: `grep -L last_comment_id <RUN_DIR>/pr-*/status.md` after a sub-60s runner exit.
+
+**Workaround:** write a watermark-skip-override directive with explicit `Process inline comment id=<N>. Either <implement fix> or <post public reply explaining deferral>.` The agent reads it in step 1 and proceeds past the directive check.
+
+**Root-cause fix candidates:**
+1. Runner pre-flight preserves prior `last_*` fields when bumping milestone to `launching` (don't overwrite the whole file).
+2. Addresser prompt step 2 fails loudly when `status.md` exists with `started_at` but no `last_comment_id` — corrupt state, not first-run.
+3. Reply-only exit paths must still append a `results.md` round + write `status.md` with `milestone: done` (or `addressed-via-reply`) and the refreshed watermark.
+
+**Related:** "Re-Review Body-Only Finding Hidden by Reaction-Advanced Watermark" above — same hidden-work shape, classification cause rather than watermark loss.

--- a/claude/learnings/claude-code/multi-agent/quality.md
+++ b/claude/learnings/claude-code/multi-agent/quality.md
@@ -105,3 +105,13 @@ Delegation prompts shaped "find X **not already in** Y" (dedupe against existing
 ## Subagent Bullet Summaries Strip Load-Bearing Specifics
 
 When promoting subagent findings to durable docs (learnings, ADRs, RFCs), bullet-form summaries often drop qualifiers the full source contains — the `is_finite()` companion guard to a `Decimal` coercion, the preflight error-elimination that makes `|| true` correct, the regex-arm ordering that makes ambiguity testable. Grep the source artifacts the agent cited before writing — bullets are an inventory, not a contract.
+
+## Subagent Constraint Relaxation: Replace + Enumerate + Mandate Autonomy
+
+When relaxing a hard-ruled constraint in a subagent prompt template (e.g., template says *"work only from the diff, do not read repo files"*), the relaxation must do three things:
+
+1. **Replace, don't stack.** "You may also Read files for verification" leaves both rules active and the agent fills the ambiguity with permission-experimentation. Phrase as replacement: *"Override: instead of working only from the diff, you may also Read individual files for path verification."*
+2. **Enumerate allowed mechanisms.** Vague "you may verify paths" lets the agent reach for whatever tool first surfaces a permission prompt (`ls /Users/...`, `cat`, `find`) and stop to ask the orchestrator. Spell out the shape: *"Use `Read(absolute_path)` for files; `ls <CWD-relative>` for directories. Avoid `ls /Users/...` absolute paths — they prompt."*
+3. **Mandate autonomy.** Add explicitly: *"Complete the deliverable autonomously. Log friction as a low-severity finding and continue — do not stop the review to ask the orchestrator meta-questions."* Without this, agents treat permission friction as a blocker and return half-baked output requiring relaunch with corrective guidance.
+
+Symptom of missing any of the three: subagent returns a meta-question ("should I use ls or Read?") instead of the findings JSON, costing a full retry-launch cycle. All three are cheap at prompt-construction time and prevent the most expensive failure mode in review-skill orchestration.

--- a/claude/learnings/claude-code/platform-tools-and-automation.md
+++ b/claude/learnings/claude-code/platform-tools-and-automation.md
@@ -19,6 +19,8 @@ When monitoring background Bash commands launched with `run_in_background: true`
 - `TaskOutput` with `block: true` and a timeout waits for completion cleanly
 - Ad-hoc Bash commands on output files require Bash permission patterns that aren't typically pre-configured, causing repeated permission prompts
 
+**Don't spawn a redundant wait-loop.** Background Bash tasks auto-emit a `<task-notification>` when they exit — re-spawning a second background task as an `until [ -f .../task-id.exit ]; do sleep 2; done` polling loop wastes a permission prompt slot and burns CPU until you manually stop it (the `.exit` marker file isn't created by the harness, so the loop never satisfies). If you need to chain work after a background task, the completion notification re-invokes you with full context; just return from the turn and wait.
+
 ## WebFetch Cannot Parse PDF Files
 
 `WebFetch` returns raw binary for PDFs — it can't extract text. The `Read` tool supports PDFs natively but requires `poppler-utils` (`brew install poppler`). If poppler isn't available, find text conversions via web search (gists, blog summaries, markdown conversions) as a fallback.
@@ -223,6 +225,19 @@ When the same string appears in multiple locations of a file (e.g., a cross-ref 
 ```
 
 Zero context cost until the condition fires. Use `@` for guidelines that apply every session; use tables for domain-specific deep references that only matter in certain tasks.
+
+## Edit/Write Refuses Symlinked `file_path` — Resolve First
+
+The Edit and Write tools reject paths that resolve to a symlink with: `Refusing to write through symlink: <path>. Resolve the symlink and pass the real target path explicitly.` This is a runtime safety guard, not a permission rule — it fires regardless of allowlist patterns. Read tolerates symlinks; only writers reject.
+
+Workaround:
+
+```bash
+readlink ~/.claude/settings.local.json
+# /Users/<user>/WORKSPACE/dotfiles/claude/settings.local.json
+```
+
+Then pass the resolved absolute path to Edit/Write. Common trip points: individually-symlinked entries under `~/.claude/` (`CLAUDE.md`, `settings.json`, `settings.local.json`) — directory-level symlinks (`commands/`, `learnings/`) are normalized through earlier and don't trigger this guard.
 
 ## Cross-Refs
 

--- a/claude/learnings/claude-code/sweep-sessions.md
+++ b/claude/learnings/claude-code/sweep-sessions.md
@@ -179,6 +179,15 @@ Issues created by the director from a confirmed parent plan (e.g., #92/#93 from 
 
 Platform-command scripts use `<PLACEHOLDER>` syntax (e.g., `gh pr view <N> --json ...`) which isn't valid bash. `bash -n` verification triggers permission denials (no allow pattern for `bash -n`) and would fail on syntax anyway. The scripts are command templates, not executable scripts — validation should check format/structure, not bash syntax. Don't add a `bash -n` permission pattern for these.
 
+**Helper search corollary:** when looking for a skill-reference helper to satisfy an operator's "is there a script for this?" question, the `.sh` files split into two shapes:
+
+| Shape | Location pattern | Invocation | Examples |
+|-------|------------------|-----------|----------|
+| Executable wrapper | `~/.claude/skill-references/*.sh` (top level) | `bash <path> <args>` | `sweep-status-summary.sh`, `init-sweep-pr-dir.sh`, `director-bootstrap.sh` |
+| Template stub | `~/.claude/skill-references/<platform>/commands/*.sh` | Inlined into prompts via `fill-template.sh`; placeholders like `<N>` | `fetch-pr-watermark.sh`, `check-pr-mergeable.sh`, `consolidated-fetch.sh` |
+
+Top-level `.sh` files are runnable. Per-platform `commands/` `.sh` files are command-text templates — open one to confirm: a single `gh pr view <N> --json …` line is a stub. When no executable wrapper exists, fall back to plain allowlisted CLI (`gh pr view <N> --json state,mergeable`), and parse JSON via `jq` — not `gh -q` with a quoted format string (those trip permission prompts).
+
 ## Confirmer Should Pre-Seed Sub-Issue Approval
 
 When a confirmer proposes sub-issues as part of its confirmation comment, it should also post approval comments on those sub-issues (after the director creates them). This eliminates the manual step where the operator or director must post "Plan confirmed from #N. Implement." before the assessment can assign the implement role. The confirmer already has the confirmed plan context — it can propagate approval downstream.

--- a/claude/learnings/claude-code/web-session-sync.md
+++ b/claude/learnings/claude-code/web-session-sync.md
@@ -34,6 +34,15 @@ Lives in `.claude/web-skills/web-create-pr/SKILL.md`. When invoked from a web se
 3. Prompts user on conflicts (no auto-resolve)
 4. Pushes with `--force-with-lease` and creates a clean PR against main
 
+### When the Guard Fails: Rebase, Don't Repoint
+
+`guard-commands` failure prints the fix verbatim: `git rebase --onto origin/main <skills-commit-sha>`. Follow it. Repointing the PR base to `web-session` makes the check inapplicable but is wrong twice:
+
+1. `web-session` is force-pushed by `sync-web-session.yml` on every push to main — anything merged into it is overwritten on the next sync.
+2. Workflow updates and docs need to land on `main` to take effect; `web-session` is derived.
+
+Confirm the situation with `git log --oneline origin/main..HEAD` — a `[web-session] sync skills` commit in the output is the trigger. After rebase, `gh pr edit <N> --base main` + force-push to land it.
+
 ## Future Simplification
 
 `/web-create-pr` is fully repo-agnostic — no project-specific references. Candidate for promotion to dotfiles (`~/.claude/commands/`), which would reduce per-project setup from 3 files to 2 (just the workflows). Deferred until the pattern is validated across multiple repos.

--- a/claude/learnings/code-quality-instincts.md
+++ b/claude/learnings/code-quality-instincts.md
@@ -370,6 +370,10 @@ Defense: pair the sign/finite check with a **magnitude ceiling** — per-symbol 
 
 To verify what a vendor actually serves, write a probe that calls the underlying client/API directly and **skips the production converter/validator path** — otherwise the validator short-circuits on the first bad bar and you see the post-rejection view, not ground truth. Pattern: same window + same signature checks across vendors, raw response saved to a gitignored scratch path for replay, the probe script committed alongside a findings doc so spot-checks stay reproducible.
 
+## Adding to default-iterated registries: verify before adding
+
+Adding an entry to a list/dict iterated by default (`_DEFAULT_*` maps, ticker tables, plugin registries) makes iteration fail-fast on any failing entry — later entries get skipped. Verify in isolation (probe / dry-run) before adding to the default, or make iteration error-tolerant per-entry (try/except + WARN, continue).
+
 ## Cross-Refs
 
 - `~/.claude/learnings/process-conventions.md` — complementary process-level patterns

--- a/claude/learnings/code-quality-instincts.md
+++ b/claude/learnings/code-quality-instincts.md
@@ -352,24 +352,6 @@ Diagnostic: trace which ledger each consumer reads. If sizing/decisions read led
 
 Common shape: one ledger uses a domain multiplier (point_value, FX rate, scale factor), the other doesn't. Whichever side gets read by the *next* sizing decision becomes the rate-limiter on system behavior. Fix at the seam: either teach the dumb ledger the multiplier (couples it to domain), or settle the domain math externally and post the result as a normalized cash delta (keeps the dumb ledger asset-class-agnostic).
 
-## Vendor APIs use sentinel values for "no data" in numeric fields
-
-Some vendor APIs return numeric sentinels (e.g., `-2**31 / 100 = -21_474_836.48`, `-999`, `9999.99`) for "no data" instead of null. They pass `isfinite()` and aren't negative-volume — they slip through standard validators and persist as if they were real values.
-
-Defensive validation at the vendor seam: gate on **domain-realistic ranges**, not just type/finite checks. For prices specifically, `val <= 0` is always wrong. Raise loud (don't silently filter) so corrupt rows never persist as "reproducible truth" — the operator can re-fetch with a later start date past the corruption.
-
-Audit any `or 0`, `get(field, 0)`, finite-checks-without-range-check on numeric fields from external sources.
-
-## Vendor-divergent failure modes on shared upstream data
-
-Multiple vendors that wrap the same upstream (corporate-actions, pricing, reference data) each apply their own cleanup pass — **failure modes diverge even when the underlying garbage is shared**. A `val > 0` guard catches one vendor's signed-cents underflow but waves through another vendor's positive-but-absurd magnitude. Concrete: TS returns `-21_474_836.48` sentinels for missing UVXY days; Schwab returns positive bars in the hundreds of billions of dollars (`Close=$514,500,000,000`) over the same window because of bad split-adjustment math. Both are unusable; only one trips a sign check.
-
-Defense: pair the sign/finite check with a **magnitude ceiling** — per-symbol upper bound, per-asset-class cap, or a percent-change-since-listing sanity check. Keep both: positive-but-billions and negative-cents are both "no data," but only different validators catch each.
-
-## Probe vendors below your validator
-
-To verify what a vendor actually serves, write a probe that calls the underlying client/API directly and **skips the production converter/validator path** — otherwise the validator short-circuits on the first bad bar and you see the post-rejection view, not ground truth. Pattern: same window + same signature checks across vendors, raw response saved to a gitignored scratch path for replay, the probe script committed alongside a findings doc so spot-checks stay reproducible.
-
 ## Adding to default-iterated registries: verify before adding
 
 Adding an entry to a list/dict iterated by default (`_DEFAULT_*` maps, ticker tables, plugin registries) makes iteration fail-fast on any failing entry — later entries get skipped. Verify in isolation (probe / dry-run) before adding to the default, or make iteration error-tolerant per-entry (try/except + WARN, continue).
@@ -378,3 +360,4 @@ Adding an entry to a list/dict iterated by default (`_DEFAULT_*` maps, ticker ta
 
 - `~/.claude/learnings/process-conventions.md` — complementary process-level patterns
 - `~/.claude/learnings/refactoring-patterns.md` — refactoring methodology
+- `~/.claude/learnings/financial/vendor-divergence.md` — vendor-specific validation patterns relocated from this file

--- a/claude/learnings/code-quality-instincts.md
+++ b/claude/learnings/code-quality-instincts.md
@@ -273,6 +273,103 @@ When a directory's contents change frequently (data files, generated artifacts, 
 
 When a system has both committed-to-git stable inputs (reproducible across commits) and dynamically-fetched data (broker/API/today's response), have one lookup function try the committed cache first, ephemeral cache second, dynamic fetch last. **Critical invariant: dynamic fetches write only to the ephemeral cache, never to the committed one.** Otherwise a fresh API call silently overwrites your reproducible fixture and tests start drifting. The committed cache stays ground truth, mutated only via an explicit operation (a fetcher script run, a vendor backfill). Per-key automatic preference means a single consumer can mix sources transparently — committed for keys that have it, ephemeral for the rest, no flag, no fallback chain to manage.
 
+## Trailing-edge mid-formation bars in append-only caches
+
+Append-only caches with `prefer="existing"` (or any "existing wins on overlap") merge policy cement any mid-period snapshot the previous run wrote. If the fetcher runs mid-session/mid-bar and writes the still-forming bar, the next refresh's *finalized* end-of-period bar is dropped — its `datetime` collides with the snapshot, and existing wins. The cache silently degrades to mid-formation state for that period forever.
+
+Fix: drop existing bars whose timestamp is at/after the start of the currently-open period **before** the merge. Compute a per-Unit cutoff (start-of-today UTC for Daily, start-of-current-bucket for Minute, ISO-Monday for Weekly, first-of-month for Monthly), filter `existing` to bars `< cutoff`, then merge. Finalized prior-period bars stay protected; the trailing edge yields to the fresh fetch.
+
+```python
+cutoff_ms = _current_period_cutoff_ms(unit, interval)
+finalized_existing = [c for c in existing if c["datetime"] < cutoff_ms]
+merged = merge_candles(finalized_existing, fetched, prefer="existing")
+```
+
+Sub-case of the "Cache layering" entry above — the one-way-write invariant doesn't help when the writer writes garbage early. Same hazard whenever a refresh policy biases toward existing on conflict and a refresh can run before the period closes.
+
+## Two near-duplicate functions differing only in body work → callable-param helper
+
+When two public functions share 90%+ of their body and differ only in one line of work (`json.dump(data, f)` vs `f.write(content)`, etc.), extract one private helper that takes a `write_fn` (or `body_fn`/`work_fn`) callable and pass the body-specific call as a lambda. Cleaner than a string-discriminator branch (`if mode == "json": ...`) because the caller's intent is a function, not a flag.
+
+```python
+def _write_atomic(path, write_fn):
+    target = Path(path); target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=str(target.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f: write_fn(f)
+        os.replace(tmp_path, target)
+    except BaseException:
+        try: os.unlink(tmp_path)
+        except FileNotFoundError: pass
+        raise
+
+def write_json_atomic(path, data, *, indent=2):
+    _write_atomic(path, lambda f: json.dump(data, f, indent=indent))
+
+def write_text_atomic(path, content):
+    _write_atomic(path, lambda f: f.write(content))
+```
+
+Pairs with the "Avoid unnecessary wrapper methods" entry — the inverse case. The 1-line wrappers stay because they document the public API + provide type signatures + are the import target. The shared helper is private and absorbs the ceremony.
+
+## Keep a 1-line wrapper that carries non-obvious work or has multiple call sites
+
+The "Avoid unnecessary wrapper methods" entry targets pure delegation (`def get_user(): return self._svc.get_user()`). Two situations where a small wrapper *is* worth keeping:
+
+1. **Non-obvious work in the body.** `iso_to_epoch_ms(s)` looks like 1 line but encodes the `tzinfo is None → replace(tzinfo=UTC)` defaulting choice. Inlining duplicates the conditional at every call site or silently drops it (and the next inline copy will).
+2. **Multi-call usage of a literal one-liner.** `epoch_ms_to_iso(ms)` is genuinely `datetime.fromtimestamp(ms/1000, tz=UTC).isoformat().replace("+00:00", "Z")`. Used once → inline. Used three times → keep the name; inlining duplicates the formatting choice (`.replace("+00:00", "Z")`) three places, so a future tweak has to be applied three times.
+
+Filter: inline when the wrapper is *both* pure delegation *and* called once. Keep when either condition fails.
+
+## Intent comments (WHY) vs narration comments (WHAT)
+
+When trimming code-narrating comments, distinguish the two:
+
+- **Keep intent.** `# Walk lower-priority source first so higher-priority overwrites on overlap` — explains *why* the loop is structured that way (priority semantics on overlap). The structure isn't obvious from the code alone.
+- **Drop narration.** `# Source labels match parameter names so error messages name the offending argument directly` — restates a one-line decision visible from the code. The next reader will see `("new", new)` and `("existing", existing)` and connect the dots.
+
+Filter: if removing the comment leaves the same teaching to a reader who reads the code, drop it. If the structure looks arbitrary without the comment, keep it. Agent-authored code tends to over-narrate the WHAT — this is a high-yield trim pass.
+
+## Asymmetric policies between sibling readers — document once, point from helpers
+
+When two readers of the same file/data shape have different error policies (fail-loud vs log-and-skip; halt-on-corrupt vs degrade-and-continue), don't duplicate the rationale on each helper's docstring — the policy is one invariant. Move the explanation to one shared owner (the public function the helpers are reachable through, or the module docstring of the file that hosts the lookup path), and leave a one-liner pointer on each helper:
+
+```python
+def _load_from_perpetual_daily(ticker):
+    """Return perpetual candles for `ticker`, or None on miss/empty.
+
+    Fails loud on corrupt JSON — see module docstring for the policy rationale.
+    """
+```
+
+Same SSOT principle as code/types — the policy is a definition, and definitions have one canonical home. Readers of the public API see the asymmetry once; helper-level doc churn drops; future updates change one paragraph instead of N near-copies.
+
+## Two-ledger divergence — parallel state systems must encode the same domain rules
+
+When two systems track the same domain quantity (analytics ledger + cash ledger; orders DB + payments DB; cache + source-of-truth), they can drift if they encode different domain math. The bug is invisible until a downstream consumer reads the wrong ledger.
+
+Diagnostic: trace which ledger each consumer reads. If sizing/decisions read ledger A and reporting reads ledger B, and A and B disagree, the system has internally inconsistent state. Tests of either ledger in isolation pass — only end-to-end runs that exercise the consumer surface the divergence.
+
+Common shape: one ledger uses a domain multiplier (point_value, FX rate, scale factor), the other doesn't. Whichever side gets read by the *next* sizing decision becomes the rate-limiter on system behavior. Fix at the seam: either teach the dumb ledger the multiplier (couples it to domain), or settle the domain math externally and post the result as a normalized cash delta (keeps the dumb ledger asset-class-agnostic).
+
+## Vendor APIs use sentinel values for "no data" in numeric fields
+
+Some vendor APIs return numeric sentinels (e.g., `-2**31 / 100 = -21_474_836.48`, `-999`, `9999.99`) for "no data" instead of null. They pass `isfinite()` and aren't negative-volume — they slip through standard validators and persist as if they were real values.
+
+Defensive validation at the vendor seam: gate on **domain-realistic ranges**, not just type/finite checks. For prices specifically, `val <= 0` is always wrong. Raise loud (don't silently filter) so corrupt rows never persist as "reproducible truth" — the operator can re-fetch with a later start date past the corruption.
+
+Audit any `or 0`, `get(field, 0)`, finite-checks-without-range-check on numeric fields from external sources.
+
+## Vendor-divergent failure modes on shared upstream data
+
+Multiple vendors that wrap the same upstream (corporate-actions, pricing, reference data) each apply their own cleanup pass — **failure modes diverge even when the underlying garbage is shared**. A `val > 0` guard catches one vendor's signed-cents underflow but waves through another vendor's positive-but-absurd magnitude. Concrete: TS returns `-21_474_836.48` sentinels for missing UVXY days; Schwab returns positive bars in the hundreds of billions of dollars (`Close=$514,500,000,000`) over the same window because of bad split-adjustment math. Both are unusable; only one trips a sign check.
+
+Defense: pair the sign/finite check with a **magnitude ceiling** — per-symbol upper bound, per-asset-class cap, or a percent-change-since-listing sanity check. Keep both: positive-but-billions and negative-cents are both "no data," but only different validators catch each.
+
+## Probe vendors below your validator
+
+To verify what a vendor actually serves, write a probe that calls the underlying client/API directly and **skips the production converter/validator path** — otherwise the validator short-circuits on the first bad bar and you see the post-rejection view, not ground truth. Pattern: same window + same signature checks across vendors, raw response saved to a gitignored scratch path for replay, the probe script committed alongside a findings doc so spot-checks stay reproducible.
+
 ## Cross-Refs
 
 - `~/.claude/learnings/process-conventions.md` — complementary process-level patterns

--- a/claude/learnings/docker-compose-patterns.md
+++ b/claude/learnings/docker-compose-patterns.md
@@ -95,3 +95,20 @@ Migrating a canonical filesystem path inside the container (e.g. `read_x` falls 
 Before merging a path-migration PR, grep `docker-compose.yaml`, runbooks, terraform, and any `update_image_*.sh` scripts for the legacy filename and update each. Smoke check: `docker run --rm` the container, mutate state, exit, then re-mount and re-run — if the second run sees stale state, the mount and the canonical path disagree.
 
 Symptom in stateful order-flow systems: action committed externally (broker fill, payment posted) and persisted in-container, `--rm` kills the container, host file still reflects pre-action state, next iteration sees stale state and re-runs the action → duplicate effect. Recovery: `docker cp` from a still-running container, or reconstruct from the external system of record.
+
+## Bind-mount inherits host file perms; strict-perm apps need host-side chmod
+
+Single-file bind-mounts (`-v host/cred.json:/ctn/cred.json`) inherit the host file's mode verbatim into the container. Apps enforcing strict perms on credentials (e.g. `0o600` token files, SSH keys, GPG keyrings) trip immediately if the host file is `0o644`/`0o664`:
+
+```
+PermissionError: Token file /ctn/cred.json has insecure permissions 0o664; expected 0o600
+```
+
+Fix is on the host, not in the container or Dockerfile: `chmod 600 ~/path/to/cred.json`.
+
+Compounds with the EBUSY/atomic-rename pattern above: if the app *also* rotates the file (`os.replace` → EBUSY → in-place fallback → `os.fchmod 0o600`), the fallback's `fchmod` may not propagate on some kernels. Worst case: rotation succeeds with the file at default umask (`0o644`), strict-perm check fires on the *next* read, container restarts into a crash loop until host `chmod 600` is reapplied. Directory mount avoids both. Logs that signal the degraded path:
+
+```bash
+docker logs <ctn> 2>&1 | grep -E 'EBUSY|fchmod|insecure permissions'
+```
+First warning = degraded but working. Second (`insecure permissions ... after EBUSY fallback`) = next read will crash.

--- a/claude/learnings/docker-image-patterns.md
+++ b/claude/learnings/docker-image-patterns.md
@@ -1,0 +1,93 @@
+Docker image patterns — image ref grammar, WORKDIR vs relative paths, multi-service run, image disk reclaim.
+- **Keywords:** image tag, repo:tag, repo-tag, GHCR, registry path, WORKDIR, relative path, CWD, configparser, docker run -d, --restart, detached, multi-service, docker rmi, dangling, shared layers, "0B reclaimed"
+- **Related:** ~/.claude/learnings/docker-compose-patterns.md
+
+## `:` is the only tag separator — `repo-<hash>` creates N repositories
+
+OCI grammar is `[registry/]repository[:tag][@digest]`. The colon is the *only* token Docker parses as a tag separator. `ghcr.io/org/foo-<hash>` is one *repository path* with implicit `:latest`; `ghcr.io/org/foo:<hash>` is repo `foo` with tag `<hash>`.
+
+The dash form looks superficially like versioning but breaks every tag-aware affordance:
+
+| Operation | `repo:tag` form | `repo-<hash>` form |
+|---|---|---|
+| `docker images foo` lists all versions | ✓ | ✗ (each version is a different repo) |
+| Retention policy / vulnerability scan attaches per repo | One target, many tags | Fragmented across N one-tag repos |
+| Rollback alias (`:stable`, `:latest`) | Cheap | Requires re-tag-and-push per alias |
+| Compose `image: foo:${TAG}` resolves | ✓ | ✗ (different repo path) |
+
+If you see a publish script doing `BASE-$(git rev-parse HEAD)` as the *repository* path with no explicit tag, that's the bug. Fix:
+
+```bash
+docker build -t "$BASE:$HASH" -f ... .
+docker tag "$BASE:$HASH" "$REGISTRY/$NAMESPACE/$BASE:$HASH"
+docker push "$REGISTRY/$NAMESPACE/$BASE:$HASH"
+```
+
+Pre-existing dash-form repos on the registry are orphans after the fix; cleanup is optional. Compose, runbook docs, and any retag-aware code must be updated together — a half-migrated state where publish uses `:` but compose still expects `-` resolves to nothing on pull.
+
+## WORKDIR drives relative-path resolution for in-container code
+
+Container code using relative paths (e.g. `configparser.ConfigParser().read("config/.env")`) resolves against the process CWD, which is the Dockerfile's `WORKDIR`. Two images reading the same relative path with different WORKDIRs read different files. Symptom: bind-mount appears correct, but the app raises a KeyError or missing-section error on data that *is* in the mounted file because the app is reading a different file entirely.
+
+```
+# Image A: WORKDIR /workspace → reads /workspace/config/.env
+# Image B: WORKDIR /opt       → reads /opt/config/.env
+
+# Bind-mount: -v host/cfg:/workspace/config/.env
+# Effective in Image A: ✓
+# Effective in Image B: ✗ — image reads /opt/config/.env, mount is a no-op
+```
+
+Fix is in the Dockerfile, not the caller — align WORKDIR across images that share calling conventions (run scripts, compose mount targets). Don't fix by adjusting the mount target per image; that fragments runbook commands.
+
+`COPY config config` with a missing `config/.env` in the build context (gitignored credentials file) bakes nothing at `/opt/config/.env`; the app then sees an empty file (or a stale one from build context) instead of the mounted file. The KeyError is the loudest symptom of WORKDIR mismatch.
+
+## Multi-service `docker run` needs `-d`; foreground blocks the chain
+
+`docker run -i -t image` attaches the caller's stdin/stdout and blocks until the container exits. Chaining a second `docker run` after it in a script means the second never starts unless the first is killed. For multi-service runtime managed by a single script:
+
+```bash
+docker run -d --restart unless-stopped --name svc-a ... image     # detached
+docker run -d --restart unless-stopped --name svc-b ... image     # also detached
+docker ps                                                         # confirm both up
+```
+
+`--rm` is incompatible with `--restart` (Docker rejects it) — `--rm` for one-shot interactive testing, `--restart` for long-running services. Mixing `-i -t` with `-d` is legal but pointless; `-d` already detaches, the `-i -t` are no-ops.
+
+Compose handles this natively (every service is detached by default), so legacy `docker run`-based update scripts that grew from a single-service era often need this fix when extended to a second service.
+
+## `docker rmi` reports "0B reclaimed" when removing shared-layer refs
+
+After `docker image prune -f` or `docker rmi <id>` on dangling images that share layers with tagged ones, Docker prints:
+
+```
+Total reclaimed space: 0B
+```
+
+This is misleading. Disk wasn't freed *by this command* because the underlying layer blobs are still referenced by tagged images. The dangling refs got *untagged* (the goal), and disk frees later when the last reference goes. The actual disk delta is visible via `docker system df` before/after a sequence of cleanups.
+
+Counter-example where you *do* see real reclaim: removing the last reference to an image with unique layers (e.g., a stale tagged build from months ago that doesn't share with anything current). Then `Total reclaimed` matches the image size.
+
+Useful pattern: chain cleanup steps and only check `docker system df` at the end, not per-step:
+
+```bash
+# Remove a known cruft pattern (e.g., one-repo-per-commit orphans)
+docker images --format '{{.Repository}}:{{.Tag}}' | grep -E '^repo-[a-f0-9]+:' | xargs docker rmi
+# Then dangling
+docker image prune -f
+# Finally measure
+docker system df
+```
+
+## `--entrypoint <interpreter>` smoke-tests config-dependent containers
+
+To verify a bind-mounted config or env file reaches the right path *without* triggering the image's default entrypoint (long-running service, OAuth flow, etc.):
+
+```bash
+docker run --rm \
+  -v "$PWD/config:/workspace/config" \
+  --entrypoint python \
+  "$IMAGE" -c "import configparser; c=configparser.ConfigParser(); c.read('config/.env'); print(c.sections())"
+```
+
+`--entrypoint` overrides the Dockerfile's `ENTRYPOINT` for one invocation. The image's `CMD` becomes args to the new entrypoint, so `-c "..."` runs an inline probe. Works for any interpreter (`python`, `node`, `ruby`, `sh`). Pairs with the WORKDIR pattern above — the probe path is WORKDIR-relative, so this validates the mount target *and* the WORKDIR resolution together.

--- a/claude/learnings/financial/CLAUDE.md
+++ b/claude/learnings/financial/CLAUDE.md
@@ -17,3 +17,4 @@ Financial and ledger engineering: monetary calculations, ledger architecture, pr
 | futures-tick-rounding.md | Per-contract tick grid (MNQ=0.25, VX/VXM=0.05) — `round(price, 2)` rejects on Cboe; snap with `round(round(p/tick)*tick, 4)` |
 | market-calendars.md | Market-calendar library selection — disentangle from DataFrame library choice (NYSE holidays, futures roll math) |
 | scheduling-time-windows.md | Runtime gates from time windows: cross-midnight wrap, weekday/market-aware open-days, derive-from-window sleep cadence |
+| tradestation-api.md | TradeStation Web API gotchas: AccountType gating (Futures can't hold equities), OrderID precedes margin validation, DAY-vs-GTC market-hours rule, orderconfirm as permission gate, 403 on options chains, futures-option symbol format |

--- a/claude/learnings/financial/CLAUDE.md
+++ b/claude/learnings/financial/CLAUDE.md
@@ -18,3 +18,4 @@ Financial and ledger engineering: monetary calculations, ledger architecture, pr
 | market-calendars.md | Market-calendar library selection — disentangle from DataFrame library choice (NYSE holidays, futures roll math) |
 | scheduling-time-windows.md | Runtime gates from time windows: cross-midnight wrap, weekday/market-aware open-days, derive-from-window sleep cadence |
 | tradestation-api.md | TradeStation Web API gotchas: AccountType gating (Futures can't hold equities), OrderID precedes margin validation, DAY-vs-GTC market-hours rule, orderconfirm as permission gate, 403 on options chains, futures-option symbol format |
+| vendor-divergence.md | Cross-vendor data quality: sentinel values, divergent failure modes on shared upstream, probe-based validation bypass |

--- a/claude/learnings/financial/futures-etf-translation.md
+++ b/claude/learnings/financial/futures-etf-translation.md
@@ -79,6 +79,65 @@ For futures market orders (and any non-idempotent broker call), retry-on-failure
 
 **Cancel-and-replace is the safe counter-pattern.** A blind retry on the original place call is dangerous. A cancel-and-replace LMT ladder (poll order state → confirm fill → cancel before placing replacement) preserves safety because each new placement happens only after the previous order's state is broker-confirmed. The dangerous pattern is unconditionally retrying the place; the safe pattern is conditioning each placement on a prior fill check. This is what makes equity-style LMT ladders safe to port to futures despite the no-blind-retry rule.
 
+## Leveraged ETF ≠ underlying future even when "labels match" (UVXY vs +@VX)
+
+Don't assume `UVXY → +@VX` is a clean substitute just because both are "VIX exposure." Empirically: UVXY's daily return beta to back-adjusted continuous VX is **~2.67×** (correlation 0.805, vol ratio 3.32×, measured 2016-2026 on clean rows). Two compounding sources:
+
+1. **Different underlying.** UVXY tracks a *daily-rebalanced rolling basket* of near-month VIX futures (~50/50 month-1 + month-2). VX is a single front-month contract. The basket is intrinsically more volatile than back-adjusted continuous VX (the back-adjustment smooths roll cost into price drift, dampening per-day vol).
+2. **1.5× ETF leverage** stacked on top of (1).
+
+Single-day examples on big vol-ups: UVXY/VX ratio ranges 1.18× to 4.05×. Volmageddon (2018-02-05): VX +16.3%, UVXY +66.2% (4.05×). Algo strategies tuned on UVXY's payoff profile won't generalize to `+@VX` at the same notional sizing — what was a profitable vol-spike capture in the ETF can become a losing leg in the future.
+
+If the ETF→future translation premise is "1:1 contract parity," that's a *slot-count* parity, not a *vol-exposure* parity. Verify with empirical beta before assuming the algo's edge transfers.
+
+## Two senses of futures leverage — margin efficiency vs vol-sensitivity per cash dollar
+
+"Futures are more leveraged than ETFs" is correct in *one* sense and wrong in the other. Distinguish before reasoning about expected P/L:
+
+| Sense | Definition | Winner (VX vs UVXY at $20k) |
+|---|---|---|
+| **Capital/margin leverage** | Notional held per dollar of cash margin posted | VX wins — $18k notional on ~$13k margin = 1.4× |
+| **Vol-exposure per cash dollar deployed** | $-P/L for a 1% move in the underlying, per dollar of cash | UVXY wins — ~3× the VX-equivalent vol exposure for the same starting cash |
+
+Slot-count sizing rules (`floor(cash / $20k_notional)`) under-deploy margin: the algo only uses ~$13k of $20k as VX margin, leaving $7k idle. Maximum-margin sizing would close that gap somewhat, but per-cash vol-sensitivity is bounded above by the *product* (multiplier × underlying-volatility), and the underlying matters more than the leverage label.
+
+When evaluating a new vol product or sizing-policy override: ask which leverage sense your algo's P/L lives on. Signal-driven entries that pay off on vol shocks live on sense 2; capital-efficient hedges live on sense 1. They're not interchangeable.
+
+## Margin-call survival check for leveraged-futures backtests
+
+Most backtesters don't enforce broker margin-call mechanics — equity goes negative on paper, the simulator keeps running, and the final P/L includes recovery the broker would have force-liquidated out of. Compute the survival buffer at the highest sizing the run touches before trusting any leveraged-futures CAGR.
+
+Peak margin utilization = `M·m/s` where M = sizing multiplier, m = margin/contract, s = slot notional. Drawdown survival buffer = `1 − util`. If observed historical max DD exceeds the buffer, the result is paper-only.
+
+Worked example, MNQ ($4,100 margin / $20k slot):
+
+| Multiplier | Util | Survival buffer | DD 35% | DD 50% | DD 62% |
+|---|---:|---:|---|---|---|
+| 1× | 20.5% | 79.5% | ✓ | ✓ | ✓ |
+| 2× | 41.0% | 59.0% | ✓ | ✓ (9pt) | ✗ |
+| 3× | 61.5% | 38.5% | ✓ | ✗ | ✗ paper-only |
+
+Two backtests at different sizings can both "succeed" on paper while one would have been called out of position before recovery. The check is a one-line guard against publishing the paper-only one as a live recommendation.
+
+## Daily-reset ETF replication via futures: roll-slippage floor
+
+Replicating a daily-reset leveraged ETF (UVXY, TQQQ, etc.) in the underlying futures has a roll-slippage floor that **micro contracts don't reduce**. Cost lives in two-sided notional turnover × spread %, and tick size scales with point value — so % cost is identical across contract sizes:
+
+| Pair | Tick value | Notional/contract | Slippage % per notional |
+|---|---:|---:|---:|
+| VX | $50 | $18,000 | 0.278% |
+| VXM | $5 | $1,800 | 0.278% |
+| ES | $12.50 | ~$220,000 | 0.006% |
+| MES | $1.25 | ~$22,000 | 0.006% |
+
+Micro contracts save **commissions** (per-contract, 10× fewer per notional moved) but not slippage. At retail commission rates this is a 1-3% drag reduction, not the order-of-magnitude saving the granularity might suggest.
+
+**Daily roll is a swap — slippage paid on both legs.** When estimating cost from "$X/day turnover" figures, distinguish one-sided from two-sided notional or the estimate is off by 2×. A swap of `(1/dr) × N` notional means two fills per day, each crossing its own bid-ask.
+
+**ETF expense ratio encodes real institutional execution edge.** UVXY's 0.95% replicates at ~10-17%/yr drag via DIY VX/VXM at retail spreads on $1M. Crossover where DIY wins is roughly $50M+ — below that, the wrapper's pooled execution beats hand-rolled mechanics.
+
+**SPVXSTR linear roll** (UVXY's underlying index): `M1 weight = dt/dr` slides 100% → 0% over each contract month, `M2 = (dr−dt)/dr` slides 0% → 100%. Daily action: sell `1/dr` of M1 by notional, buy equivalent M2 notional. The "50/50 basket" framing is the cycle average, not the daily holding.
+
 ## Cross-Refs
 
 - `order-book-pricing.md` — Mid-price and slippage concepts apply to futures spread

--- a/claude/learnings/financial/tradestation-api.md
+++ b/claude/learnings/financial/tradestation-api.md
@@ -1,0 +1,33 @@
+TradeStation Web API behavior: account-type gating, validation ordering, TIF rules, preview endpoint, options-chain permissions, futures-option symbol formats.
+
+**Keywords:** TradeStation, TS, TS API, AccountType, Futures account, Margin account, orderconfirm, OrderID, DAY, GTC, market hours, options expirations, 403 permission, VX futures options, symbol format
+**Related:** ~/.claude/learnings/financial/futures-etf-translation.md, ~/.claude/learnings/financial/futures-order-type-restrictions.md
+
+## Account types gate asset class, not just permission
+
+`AccountType: "Futures"` accounts can't hold equities. Rejection on equity orders returns `"Closing Transactions Only - below minimum equity ratio requirement"` (not `"not approved"`) because there's no equity-margin facility against which to measure the ratio. Account types from `GET /brokerage/accounts`: `Cash`, `Margin`, `Futures`. Equity-trading scripts must resolve to a Margin or Cash account, not a Futures one.
+
+## OrderID generated before margin/account-type validation
+
+TS assigns an `OrderID` to any structurally-valid order envelope **before** running margin and account-type checks. OrderID generation is *not* proof of account permission — a rejected order can come back with a populated `OrderID` and `"Status": "REJ"`. Don't infer "account is permissioned for X" from receiving an OrderID alone; the full envelope (`Error`, `Message`, `RejectReason`) carries the actual outcome.
+
+## TimeInForce DAY rejected outside market hours
+
+`Duration: "DAY"` is only accepted while equity markets are open. Outside RTH (overnight, weekends, holidays), TS rejects with `"Only GTC/GTC+/GTD/GTD+ orders when markets are closed"`. Inspection/verification scripts that may run any time should default to `GTC`, which works in both regimes.
+
+## orderconfirm is the actual permission gate (preview without placement)
+
+`POST /orderexecution/orderconfirm` runs full margin + account-type + symbol-permission validation and returns estimated cost / commission / BP impact, **without placing the order**. Safe to call against `live` env. The orderconfirm response (`Errors` present vs `Confirmations` populated) is the definitive "can this account trade this symbol" answer — distinct from `/orderexecution/orders` which actually places.
+
+## 403 on options chain endpoints = permission gate, not missing resource
+
+`GET /marketdata/options/expirations/{underlying}` returning HTTP **403** (not 404) means the endpoint exists but the account/credentials aren't authorized — typically because real-time options data subscription is inactive, or futures-options approval is denied. Distinguishing 403-permission from 404-not-found matters when probing what an account can access; treat 403 as informative ("you can't see this") not as "doesn't exist."
+
+## Futures-option symbol format: web UI is authoritative
+
+TS's canonical futures-option symbol format isn't uniformly documented across their API surface. When `/marketdata/symbols/{guess}` returns `"invalid symbol"` on common formats (`VXM26C20`, `OVXM26C20`, `VXM26C2000`), the authoritative source is the TS web platform's option chain UI — clicking an option contract shows the exact symbol string TS expects. Trying multiple formats programmatically wastes calls; the web lookup is one click and definitive.
+
+## Cross-Refs
+
+- `futures-etf-translation.md` — ETF/futures math, margin-call survival check, daily-reset replication roll-slippage floor
+- `futures-order-type-restrictions.md` — Per-contract MKT-rejection rules (CFE VIX-family) + wide-crossing LMT mitigation

--- a/claude/learnings/financial/tradestation-api.md
+++ b/claude/learnings/financial/tradestation-api.md
@@ -1,6 +1,6 @@
 TradeStation Web API behavior: account-type gating, validation ordering, TIF rules, preview endpoint, options-chain permissions, futures-option symbol formats.
 - **Keywords:** TradeStation, TS, TS API, AccountType, Futures account, Margin account, orderconfirm, OrderID, DAY, GTC, market hours, options expirations, 403 permission, VX futures options, symbol format
-- **Related:** futures-etf-translation.md, futures-order-type-restrictions.md, vendor-divergence.md
+- **Related:** ~/.claude/learnings/financial/futures-etf-translation.md, ~/.claude/learnings/financial/futures-order-type-restrictions.md, ~/.claude/learnings/financial/vendor-divergence.md
 
 ## Account types gate asset class, not just permission
 

--- a/claude/learnings/financial/tradestation-api.md
+++ b/claude/learnings/financial/tradestation-api.md
@@ -1,7 +1,6 @@
 TradeStation Web API behavior: account-type gating, validation ordering, TIF rules, preview endpoint, options-chain permissions, futures-option symbol formats.
-
-**Keywords:** TradeStation, TS, TS API, AccountType, Futures account, Margin account, orderconfirm, OrderID, DAY, GTC, market hours, options expirations, 403 permission, VX futures options, symbol format
-**Related:** ~/.claude/learnings/financial/futures-etf-translation.md, ~/.claude/learnings/financial/futures-order-type-restrictions.md
+- **Keywords:** TradeStation, TS, TS API, AccountType, Futures account, Margin account, orderconfirm, OrderID, DAY, GTC, market hours, options expirations, 403 permission, VX futures options, symbol format
+- **Related:** futures-etf-translation.md, futures-order-type-restrictions.md, vendor-divergence.md
 
 ## Account types gate asset class, not just permission
 

--- a/claude/learnings/financial/vendor-divergence.md
+++ b/claude/learnings/financial/vendor-divergence.md
@@ -1,0 +1,28 @@
+Vendor data quality patterns: sentinel values, cross-vendor failure mode divergence, and probe-based validation bypass for ground-truth discovery.
+- **Keywords:** vendor, sentinel, TradeStation, Schwab, UVXY, VX, data quality, magnitude ceiling, probe, validator bypass, numeric range
+- **Related:** tradestation-api.md, futures-etf-translation.md
+
+---
+
+## Vendor APIs use sentinel values for "no data" in numeric fields
+
+Some vendor APIs return numeric sentinels (e.g., `-2**31 / 100 = -21_474_836.48`, `-999`, `9999.99`) for "no data" instead of null. They pass `isfinite()` and aren't negative-volume — they slip through standard validators and persist as if they were real values.
+
+Defensive validation at the vendor seam: gate on **domain-realistic ranges**, not just type/finite checks. For prices specifically, `val <= 0` is always wrong. Raise loud (don't silently filter) so corrupt rows never persist as "reproducible truth" — the operator can re-fetch with a later start date past the corruption.
+
+Audit any `or 0`, `get(field, 0)`, finite-checks-without-range-check on numeric fields from external sources.
+
+## Vendor-divergent failure modes on shared upstream data
+
+Multiple vendors that wrap the same upstream (corporate-actions, pricing, reference data) each apply their own cleanup pass — **failure modes diverge even when the underlying garbage is shared**. A `val > 0` guard catches one vendor's signed-cents underflow but waves through another vendor's positive-but-absurd magnitude. Concrete: TS returns `-21_474_836.48` sentinels for missing UVXY days; Schwab returns positive bars in the hundreds of billions of dollars (`Close=$514,500,000,000`) over the same window because of bad split-adjustment math. Both are unusable; only one trips a sign check.
+
+Defense: pair the sign/finite check with a **magnitude ceiling** — per-symbol upper bound, per-asset-class cap, or a percent-change-since-listing sanity check. Keep both: positive-but-billions and negative-cents are both "no data," but only different validators catch each.
+
+## Probe vendors below your validator
+
+To verify what a vendor actually serves, write a probe that calls the underlying client/API directly and **skips the production converter/validator path** — otherwise the validator short-circuits on the first bad bar and you see the post-rejection view, not ground truth. Pattern: same window + same signature checks across vendors, raw response saved to a gitignored scratch path for replay, the probe script committed alongside a findings doc so spot-checks stay reproducible.
+
+## Cross-Refs
+
+- `~/.claude/learnings/financial/tradestation-api.md` — TS-specific API mechanics (account gating, orderconfirm, symbol formats)
+- `~/.claude/learnings/code-quality-instincts.md` — general validation patterns (sentinel guards, sibling-field scans)

--- a/claude/learnings/financial/vendor-divergence.md
+++ b/claude/learnings/financial/vendor-divergence.md
@@ -1,6 +1,6 @@
 Vendor data quality patterns: sentinel values, cross-vendor failure mode divergence, and probe-based validation bypass for ground-truth discovery.
 - **Keywords:** vendor, sentinel, TradeStation, Schwab, UVXY, VX, data quality, magnitude ceiling, probe, validator bypass, numeric range
-- **Related:** tradestation-api.md, futures-etf-translation.md
+- **Related:** ~/.claude/learnings/financial/tradestation-api.md, ~/.claude/learnings/financial/futures-etf-translation.md
 
 ---
 

--- a/claude/learnings/git-patterns.md
+++ b/claude/learnings/git-patterns.md
@@ -1,5 +1,5 @@
 Git workflow patterns — rebase strategies, worktree isolation, lockfile conflicts, commit hygiene, file tracking, and branch management.
-- **Keywords:** rebase, worktree, cherry-pick, pnpm lockfile, force-push-with-lease, git mv, soft reset, zsh glob, stash, merge conflicts, pre-commit hooks, symlink, stale main, merge-base ancestry, post-rebase divergence, orphan commits, N-vs-N divergence, squash-merge stacked branch, rebase --onto upstream squash, auto-merge concatenation, pre-rebase semantic check, API surface compatibility, forwarding property, re-export back-compat, long-lived PR
+- **Keywords:** rebase, worktree, cherry-pick, pnpm lockfile, force-push-with-lease, git mv, soft reset, zsh glob, stash, merge conflicts, pre-commit hooks, symlink, stale main, merge-base ancestry, post-rebase divergence, orphan commits, N-vs-N divergence, squash-merge stacked branch, rebase --onto upstream squash, auto-merge concatenation, pre-rebase semantic check, API surface compatibility, forwarding property, re-export back-compat, long-lived PR, stacked-PR split, carve-out branch, cherry-pick auto-dedup, path-scoped log, textual conflict prediction
 - **Related:** ~/.claude/learnings/bash-patterns.md, ~/.claude/learnings/cicd/gitlab.md, ~/.claude/learnings/git-github-api.md
 
 ---
@@ -96,6 +96,31 @@ When a branch has commits mixing two concerns (e.g., docs + implementation plans
 5. Clean up untracked files, force-push-with-lease
 
 **Why soft-reset over interactive rebase:** When the concern boundary doesn't align with commit boundaries (e.g., first commit has files from both concerns), `reset --soft` + selective unstage is simpler than splitting commits during rebase.
+
+## Carve-Out Branch First, Then Cherry-Pick to Rewrite Source
+
+Sibling to soft-reset split — preserves the source's commit boundaries instead of collapsing. When splitting a feature branch into a stacked pair (carve-out → main, source → carve-out):
+
+```bash
+# Carve out the subset onto a new branch off main
+git checkout -b feat/foo-base origin/main
+git checkout feat/source -- <subset-paths>
+git commit && git push -u origin feat/foo-base
+
+# Rewrite source: cherry-pick original commits onto the carve-out base
+git checkout -b tmp/rewrite feat/foo-base
+git cherry-pick <orig-sha-1>            # auto-dedupes hunks already in base
+git cherry-pick <orig-sha-2>
+git branch -f feat/source HEAD           # re-point original branch
+git switch feat/source && git branch -D tmp/rewrite
+git push --force-with-lease
+```
+
+Cherry-pick detects hunks present in the new base (including byte-identical file additions) and silently drops them — the rewritten commit contains only the genuinely-new diff. No `git rm` surgery, no `cherry-pick --no-commit` + manual unstaging.
+
+Pick this over soft-reset when downstream commits depend on the source's original commit boundary structure (soft-reset collapses to one commit). Pick soft-reset when the split scope crosses commit boundaries irregularly.
+
+**Followup:** `gh pr edit <N> --base feat/foo-base` to stack the PR. After carve-out merges, plain `git rebase origin/main` auto-skips the carve-out commit (`warning: skipped previously applied commit`).
 
 ## Verify Remote/Project Identity Before Cross-Repo Work
 
@@ -453,6 +478,53 @@ Avoid copying the prerequisite's commits into your branch — creates duplicate 
 ## `--autosquash` requires `-i` — forward-fix beats workarounds
 
 `git rebase --autosquash` only works under `git rebase -i`, which the Claude Code harness disallows. `GIT_SEQUENCE_EDITOR=:` / `=true` doesn't help — the rebase still asserts on `-i`. For amending a non-HEAD commit in an unpushed feature branch, forward-fix with a follow-up commit and squash on merge (or have the operator squash locally) is simpler than any non-interactive workaround.
+
+## Path-scoped log predicts textual rebase conflicts
+
+Before `git rebase`, intersect the file-sets of both sides:
+
+```bash
+git log <merge-base>..origin/<base> --oneline -- $(git diff --name-only <merge-base>..HEAD)
+```
+
+Empty → base hasn't touched any file your branch modified → rebase is textually clean (zero conflict markers). One non-empty line per overlapping file gives you the exact conflict surface to inspect before running `rebase`.
+
+Faster than `git merge-tree` (prompts for permission in `claude -p`) and more precise than the diff-intersection fallback, which flags files-both-sides-touched but not whether main's edits land in the same hunks.
+
+Companion to "Pre-rebase semantic check" (API drift after clean textual replay) and "Post-rebase blast radius" (full test run after replay). This one decides whether you need conflict-resolution rounds at all.
+
+## Non-interactive commit splitting via edit-revert + temporal staging
+
+When one file has changes belonging to two commits and `git add -p` / `git rebase -i` are unavailable (Claude Code harness disallows interactive flags), split the file's changes by re-editing the working tree across two commits:
+
+1. Capture both deltas in your head (read `git diff <file>`).
+2. **Edit-revert** the second commit's bits in the working tree — file now contains only the first commit's changes.
+3. `git add <file>` + commit #1.
+4. **Restore** the second commit's bits via Edit (the first commit's content is now in HEAD; what remains in working tree is only the delta you just re-applied).
+5. `git add <file>` + commit #2.
+
+Cleaner than `git stash --keep-index` (interactive) or `git restore --staged` gymnastics. Test the intermediate state between steps 2 and 3 (`uv run pytest <relevant>`) to confirm the split point is coherent. Different from "Split Mixed-Concern Branch via Soft Reset" — that's for splitting *commits*; this is for splitting *file-level changes* that span two intended commits.
+
+## Pushing to a merged-and-deleted PR branch silently recreates it
+
+GitHub's auto-delete-on-merge removes the remote branch after PR squash-merge. The local clone still has the branch ref locally and `git status` may say "up to date" against a stale cached origin ref. Pushing a new commit *succeeds* but the output line is:
+
+```
+* [new branch]      mahoy/<branch> -> mahoy/<branch>
+```
+
+That `[new branch]` is the tell — origin had to create the ref fresh. The new commit is orphaned: not attached to the merged PR (closed), not attached to any open PR, not reachable from main. Easy to miss because the push didn't error.
+
+Recover by cherry-picking onto a fresh branch from main:
+```bash
+git checkout -b <new-branch> origin/main
+git cherry-pick <orphan-sha>
+git push -u origin <new-branch>
+gh pr create --base main
+git push origin --delete <recreated-stale-branch>     # cleanup the orphan ref
+```
+
+Prevent by checking PR state before pushing post-merge: `gh pr view <num> --json state` returning `MERGED` is the signal to switch to a new branch from main instead of continuing on the (now-stale) feature branch.
 
 ## Cross-Refs
 

--- a/claude/learnings/git-patterns.md
+++ b/claude/learnings/git-patterns.md
@@ -1,5 +1,5 @@
 Git workflow patterns — rebase strategies, worktree isolation, lockfile conflicts, commit hygiene, file tracking, and branch management.
-- **Keywords:** rebase, worktree, cherry-pick, pnpm lockfile, force-push-with-lease, git mv, soft reset, zsh glob, stash, merge conflicts, pre-commit hooks, symlink, stale main, merge-base ancestry, post-rebase divergence, orphan commits, N-vs-N divergence, squash-merge stacked branch, rebase --onto upstream squash, auto-merge concatenation, pre-rebase semantic check, API surface compatibility, forwarding property, re-export back-compat, long-lived PR, stacked-PR split, carve-out branch, cherry-pick auto-dedup, path-scoped log, textual conflict prediction, branch -f, rewind branch pointer, preserve dirty tree
+- **Keywords:** rebase, worktree, cherry-pick, pnpm lockfile, force-push-with-lease, git mv, soft reset, zsh glob, stash, merge conflicts, pre-commit hooks, symlink, stale main, merge-base ancestry, post-rebase divergence, orphan commits, N-vs-N divergence, squash-merge stacked branch, rebase --onto upstream squash, auto-merge concatenation, pre-rebase semantic check, API surface compatibility, forwarding property, re-export back-compat, long-lived PR, stacked-PR split, carve-out branch, cherry-pick auto-dedup, path-scoped log, textual conflict prediction, branch -f, rewind branch pointer, preserve dirty tree, stash untracked third parent, stash@{0}^3, git apply --3way dry-run, no-op patch apply, atomic commit split, temp-revert staging, preemptive PR number suffix
 - **Related:** ~/.claude/learnings/bash-patterns.md, ~/.claude/learnings/cicd/gitlab.md, ~/.claude/learnings/git-github-api.md
 
 ---
@@ -171,6 +171,41 @@ Zsh interprets `[brackets]` as glob patterns. `git add app/api/accounts/[address
 **Cross-branch:** Stash on branch A, pop on diverged branch B — files modified in the divergent commits conflict even if the stash didn't touch them. For delete/modify conflicts: `git rm <file>`. For text: keep the stash's changes.
 
 **Post-rebase:** Stash dirty files to unblock rebase, pop after completion — conflicts if rebase modified those files. Resolution: keep the rebased version (post-rebase is authoritative), drop the stash.
+
+**Untracked-file conflicts (`-u` stash):** Error reads `<file> already exists, no checkout` — stash pop refuses to overwrite. The untracked files live at `stash@{0}^3` (third parent of the stash commit; tracked changes are at `^1`/`^2`).
+
+- List: `git ls-tree -r stash@{0}^3 --name-only`
+- **Diff first** before any extraction — after a recent merge, untracked stash files are often bit-identical to what's now committed. Bisect with `diff -q <(git show stash@{0}^3:<path>) <path>` to find true differences and avoid wasted work on collisions that are noise.
+- Extract stash version side-by-side (keep both): `git archive stash@{0}^3 | tar -x -C tmp/rescued/` or per-file `git show stash@{0}^3:<path> > <dest>`.
+- Apply stash's tracked changes separately when pop is blocked atomically: `git stash show -p stash@{0} | git apply --3way`.
+
+## `git apply --3way --check` Output Is Misleading
+
+`git apply --3way --check` reports `Applied patch to '<file>' cleanly.` even though `--check` makes it a dry-run (no actual write). A 3-way merge can also resolve every hunk as already-applied — the apply succeeds without changing the tree. Either way the message is the same as a real apply.
+
+**Always verify with `git diff` / `git status` after applying.** Empty diff after `git apply --3way` (without `--check`) means the patch was a no-op — content already present, often because the source branch already absorbed those changes.
+
+## Atomic Commit Split via Temp-Revert (no `git add -p`)
+
+When you need two atomic commits from one file's changes and interactive staging (`git add -p`) is unavailable (Claude Code harness, scripted contexts), Edit-revert one slice, commit the rest, Edit-restore, commit again:
+
+1. `Edit` the file to remove the lines belonging to commit B (keep commit A's content).
+2. `git add <file> [other commit-A files]` → `git commit -F msg-A.txt`.
+3. `Edit` to restore commit B's lines.
+4. `git add -A` → `git commit -F msg-B.txt`.
+
+Verify each commit's contents with `git diff HEAD~..HEAD --stat` after the first commit to confirm only commit-A's scope landed. The intermediate state must still pass tests — choose which slice goes first accordingly (typically the standalone tooling change, then the data/config that consumes it).
+
+## Preemptive `(#NNN)` in Commit Subjects — Verify Before Pushing
+
+Claude often drafts commit subjects with placeholder PR numbers (`feat: ... (#199)`) that don't match the eventual PR. Before pushing or opening a PR:
+
+```bash
+gh pr view <NNN> --json state 2>&1   # GraphQL error → no such PR
+gh issue view <NNN> --json title     # may be an issue number instead
+```
+
+If the suffix is stale, amend the subject (`git commit --amend -F <new-msg>` with the suffix stripped) and `git push --force-with-lease`. The `#NNN` references inside the commit body may still be valid (often the parent *issue*, not the PR) — verify each separately. Related: GitHub PR and issue numbers share a namespace (`git-github-api.md` → "gh pr view <N> fails when N is an issue number").
 
 ## Symlinked Dirs Revert Edits on Branch Switch
 

--- a/claude/learnings/git-patterns.md
+++ b/claude/learnings/git-patterns.md
@@ -1,5 +1,5 @@
 Git workflow patterns — rebase strategies, worktree isolation, lockfile conflicts, commit hygiene, file tracking, and branch management.
-- **Keywords:** rebase, worktree, cherry-pick, pnpm lockfile, force-push-with-lease, git mv, soft reset, zsh glob, stash, merge conflicts, pre-commit hooks, symlink, stale main, merge-base ancestry, post-rebase divergence, orphan commits, N-vs-N divergence, squash-merge stacked branch, rebase --onto upstream squash, auto-merge concatenation, pre-rebase semantic check, API surface compatibility, forwarding property, re-export back-compat, long-lived PR, stacked-PR split, carve-out branch, cherry-pick auto-dedup, path-scoped log, textual conflict prediction
+- **Keywords:** rebase, worktree, cherry-pick, pnpm lockfile, force-push-with-lease, git mv, soft reset, zsh glob, stash, merge conflicts, pre-commit hooks, symlink, stale main, merge-base ancestry, post-rebase divergence, orphan commits, N-vs-N divergence, squash-merge stacked branch, rebase --onto upstream squash, auto-merge concatenation, pre-rebase semantic check, API surface compatibility, forwarding property, re-export back-compat, long-lived PR, stacked-PR split, carve-out branch, cherry-pick auto-dedup, path-scoped log, textual conflict prediction, branch -f, rewind branch pointer, preserve dirty tree
 - **Related:** ~/.claude/learnings/bash-patterns.md, ~/.claude/learnings/cicd/gitlab.md, ~/.claude/learnings/git-github-api.md
 
 ---
@@ -525,6 +525,17 @@ git push origin --delete <recreated-stale-branch>     # cleanup the orphan ref
 ```
 
 Prevent by checking PR state before pushing post-merge: `gh pr view <num> --json state` returning `MERGED` is the signal to switch to a new branch from main instead of continuing on the (now-stale) feature branch.
+
+## Rewind a non-current branch pointer with `git branch -f`
+
+`git branch -f <name> <ref>` moves the branch pointer to `<ref>` without checking it out — HEAD and the working tree are untouched. Use this when an unpushed commit sits on `main` and should live on a new feature branch instead, while the tree is dirty:
+
+```bash
+git switch -c feat/new          # branch at HEAD carries the unpushed commit; dirty tree follows
+git branch -f main origin/main  # rewinds main pointer; HEAD/worktree untouched
+```
+
+`git switch main && git reset --hard origin/main` would discard the dirty tree on the way back. The stash workaround (`stash --include-untracked && reset --hard && stash pop`) survives but adds round-trip risk on `pop`; `branch -f` skips it entirely.
 
 ## Cross-Refs
 

--- a/claude/learnings/process-conventions.md
+++ b/claude/learnings/process-conventions.md
@@ -1,5 +1,5 @@
 Patterns for how engineering work is organized, scoped, and tracked — PR splitting, MR scoping, phased delivery, and preparatory refactoring.
-- **Keywords:** PR splitting, MR scoping, cherry-pick, preparatory refactoring, scope creep, staged renames, plan-first PR, PR description, git history, safeguards
+- **Keywords:** PR splitting, MR scoping, cherry-pick, preparatory refactoring, scope creep, staged renames, plan-first PR, PR description, git history, safeguards, plan retirement, plan lifecycle, acceptance criteria, issue closure, tracking issue maintenance
 - **Related:** ~/.claude/learnings/review-conventions.md, ~/.claude/learnings/code-quality-instincts.md
 
 ---
@@ -13,6 +13,17 @@ rg -l "TRADING_WINDOW|TS_TOKEN_PATH" docs/ scripts/ README.md
 ```
 
 The compose value is usually the source of truth (executable); docs need to follow. Catching this at PR time is cheaper than producing a fourth contradictory source post-merge.
+
+### Cross-reference comments in executables for multi-source docs
+
+When a config value or convention lives in N doc locations *and* an executable script, add a one-line comment in the executable pointing to the canonical doc:
+
+```bash
+# Mount source: schwab.env → see docs/per-broker-env-rollout.md
+docker run -v "$PWD/config/schwab.env:/workspace/config/.env:ro" ...
+```
+
+Makes `grep schwab.env` surface all N+1 locations atomically — the executable joins the three-source-drift check above instead of hiding from it.
 
 ### Defer large cross-cutting refactors to tracked issues
 
@@ -203,3 +214,25 @@ When a feature PR series deletes/renames files that learnings/architecture docs 
 When a plan decomposes into N PRs, scaffold tracking as **one parent issue + N sub-issues**, all carrying a single per-initiative label (`mnq-myapp`, `IaC MVP`). Parent issue body: brief goal, locked architecture decisions, and a task-list of sub-issues using `- [ ] #N — title` syntax (GitHub auto-tracks completion as sub-issues close). Sub-issue bodies: `## Scope` (with "What's in PR N" / "What's NOT in PR N"), `## Acceptance criteria` (checkbox list), `## Risks`, `## Suggested lens` (which review persona is primary/secondary), `## Cross-references`. Plan.md remains the canonical living doc — issues reference it and don't duplicate decisions; updating decisions happens in the doc, not by editing N issues.
 
 Workflow: read 1–2 existing issues to learn the repo's body shape, propose a sample, get operator OK on the template before bulk-creating. Bulk-create sub-issues first (parallel `gh issue create` calls), capture their numbers from stdout, then create the parent referencing the captured numbers in the task list. GitHub-relative paths in issue bodies resolve from repo root — use `[text](docs/plans/foo/plan.md)`, not `[text](../blob/main/docs/plans/foo/plan.md)`.
+
+### Retire plan.md once issues absorb its decisions
+
+Companion to "Multi-PR plan → parent index issue" above. Plan.md is canonical *during* issue scaffolding; once sub-issues hold scope/criteria, README holds operational steps, and durable rationale has moved to learnings, plan.md drifts behind the real source of truth. Lingering stale plans confuse future readers about which document is authoritative.
+
+Audit-and-retire pass:
+
+| Plan content | Destination |
+|---|---|
+| Goal / Decisions / Action items duplicated in sub-issues | drop with the plan |
+| Deferred non-blockers (e.g., AWS Config, alternate-region dev) | tracking issue's "Future / not yet scoped" section |
+| Post-cutover cleanup (e.g., delete legacy bootstrap script) | new sub-issue with the initiative label |
+| Rejected design alternatives + verified platform constraints | learnings file |
+| Operational color (cost / timing estimates) | drop |
+
+Then delete the plan file. Heuristic for "is it time?": if the plan's "Decisions" section reads like a transcript of the sub-issue bodies, the plan has retired.
+
+### Issue closure tracks acceptance criteria, not PR merge
+
+When an issue's acceptance criteria mix code-shippable items (modules, scripts, README updates) with operator-side action (cutover, decommission, observation period, postmortem), merging the implementing PR doesn't close the issue. The issue stays open as a tracking artifact for the operator-side work, with the merged PR linked.
+
+Auditing migration progress: distinguish "PR landed, issue intentionally still open because cutover hasn't run" from "issue forgotten." A glance at the criteria checklist tells you which. Don't auto-close on merge for cutover-bearing issues.

--- a/claude/learnings/process.md
+++ b/claude/learnings/process.md
@@ -24,3 +24,19 @@ Three-layer output beats raw JSON dump:
 ```
 
 The candidate-summary header is highest-signal: proves field name AND type AND shape in one line. Verify against multiple variants (cash + margin, equities + futures) — fixture-only verification misleads because fixtures often capture one variant.
+
+### Pin a bug with a failing regression test BEFORE the fix
+
+When fixing a non-trivial bug, write the test first and confirm it fails for the reason you think the bug is. Then apply the fix and confirm the test now passes. Two payoffs: (a) you've empirically verified the bug exists where you think it does — not somewhere else producing the same symptom; (b) the test stays in the suite as a permanent regression guard against the same class of bug returning.
+
+Especially valuable for bugs found via end-to-end runs (where the symptom and root cause are several layers apart) and for shared-mutable-state bugs where the failure is order-dependent. Cheap insurance against "fixed the wrong thing" or "the fix introduced a new bug."
+
+### Diverging "same" runs → suspect ephemeral state, re-run before reasoning
+
+When two runs of nominally-identical config produce different results, suspect ephemeral state before re-deriving from logs: in-flight code state mid-edit, cached data refresh between runs, partial config-file write, an env var that got toggled. Re-run the canonical baseline in the current session against current state before drawing conclusions about which result is "correct" — saves you from analyzing a phantom run that no longer reproduces.
+
+The mistake mode is treating one of the divergent runs as authoritative and reasoning about *why it differs* from the other, when both may be artifacts. Reproducing on current state collapses the search space to one number.
+
+### Broker permission probe sequence: symbol → market-data → preview-endpoint
+
+Probe broker-account capability without risking capital by layering: (1) symbol lookup (broker recognizes it?), (2) live quote (data flowing?), (3) preview/dry-run endpoint (account accepts the order?). The preview is the definitive permission test — symbol and quote can succeed on accounts that still can't trade the instrument, because permission validation usually runs deeper in the order pipeline than market-data access.

--- a/claude/learnings/python-specific.md
+++ b/claude/learnings/python-specific.md
@@ -1,5 +1,5 @@
 Python idioms and gotchas for Pydantic v2, TypedDict, dataclasses, env var handling, and package management.
-- **Keywords:** pydantic, optional fields, model_dump, exclude_none, TypedDict, NotRequired, pyright, dataclass, __post_init__, __all__, pyproject.toml, uv, poetry, noqa, linter suppression, Protocol, PEP 544, structural typing, pydocstyle, private module, patch path, from None, exception chain, fchmod, mkstemp, fd leak, bool int subclass, isinstance bool, httpx Timeout, split phases, async blocking, sys.path, PYTHONPATH, package-mode, ModuleNotFoundError, script relocation, Docker CMD, python -m
+- **Keywords:** pydantic, optional fields, model_dump, exclude_none, TypedDict, NotRequired, pyright, dataclass, __post_init__, __all__, pyproject.toml, uv, poetry, noqa, linter suppression, Protocol, PEP 544, structural typing, pydocstyle, private module, patch path, from None, exception chain, fchmod, mkstemp, fd leak, bool int subclass, isinstance bool, httpx Timeout, split phases, async blocking, sys.path, PYTHONPATH, package-mode, ModuleNotFoundError, script relocation, Docker CMD, python -m, keyword-only, signature audit, positional-to-keyword
 - **Related:** ~/.claude/learnings/api-design.md, ~/.claude/learnings/testing-patterns.md
 
 ---
@@ -522,6 +522,18 @@ class BrokerAdapter(Protocol):
 
 Underused because the invariant feels like consumer concern. The Protocol is the contract surface — that's where the rule belongs. Pairs with `code-quality-instincts.md` → "Document non-leakage contracts on pluggable Protocol surfaces".
 
+## Keyword-only enforcement: audit external callers, not just the changed module
+
+When adding `*` to a signature to make a parameter keyword-only (`def f(x, *, datasets):`), commits typically update internal callers in the same file but skip external ones. Positional callers now `TypeError` at runtime — invisible to lint, only caught by tests that actually hit the path.
+
+Grep every callsite of every changed function across the repo before considering the refactor complete:
+
+```bash
+grep -rn -E "(fn1|fn2|fn3)\(" --include="*.py" -l | grep -v <changed-file>
+```
+
+For each hit, verify the now-keyword param is passed as `name=value`. CI passes if test coverage is thin — runtime is where it bites. Same audit discipline as renames/removals (`git-workflow.md` → "API Changes").
+
 ## DST drift in `datetime + timedelta(days=N)` vs epoch math
 
 `datetime.fromtimestamp(t) + timedelta(days=85)` adds 85 calendar days in **local time**; `datetime.fromtimestamp(t + 85 * 86_400)` adds 85 × 86,400 seconds in **UTC**. Across a DST transition these differ by an hour. For tests asserting against system computation that uses epoch arithmetic, mirror the system's math — don't reconstruct via wall-clock `timedelta`.
@@ -535,6 +547,45 @@ assert expiry == datetime.fromtimestamp(creation_ts + 85 * 86_400)
 ```
 
 Same hazard in any "deadline" / "expiry" / "bucket boundary" code that mixes `timedelta(days=...)` with epoch-based persistence.
+
+## Concurrent-writer race on deterministic `<target>.tmp` filename
+
+`tmp = target.with_suffix(target.suffix + ".tmp"); write(tmp); os.replace(tmp, target)` is atomic vs crash and concurrent readers, **not** vs concurrent writers. Two overlapping writers race on the same `.tmp`; both `os.replace` it; whichever loses has its bytes silently overwritten. Use `tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=target.parent)` per writer + `try/finally` cleanup so each writer renames its own bytes.
+
+```python
+fd, tmp_path = tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=str(target.parent))
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        write_fn(f)
+    os.replace(tmp_path, target)
+except BaseException:
+    try: os.unlink(tmp_path)
+    except FileNotFoundError: pass
+    raise
+```
+
+Common in shared atomic-write helpers reused by multiple call sites (fetcher + standalone regen script, parallel agents writing per-key files). Pairs with the `os.fdopen` ownership pattern above — each writer owns its fd from acquisition.
+
+## Argparse: validate the resolved value, not the raw `args.x or []`
+
+Parse-time gates that read `args.flag` before `main()` defaults it can miss combinations that materialize after defaulting. Symptom: `--ts-symbol @MNQ` (no `--ticker`) passes a `len(tickers) > 1` check (raw `args.ticker is None` → `[]`), then `main()` defaults `tickers = ["NQ", "QQQ"]` and `tickers[0]` silently swallows the override into one ticker only — partial-application bug.
+
+Two fixes (pick by intent):
+1. **Move validation to `main()`** after defaulting: `if args.flag and len(resolved_list) != 1: parser.error(...)`.
+2. **Require the explicit form** in `_parse_args`: `if args.flag and not args.x: parser.error("--flag requires --x to be set explicitly")`. Cleaner when "operate on all defaults" doesn't compose with the flag's semantics anyway.
+
+Family: `dict.get(k) or fb` ≠ `dict.get(k, fb)` — both are "fallback collapsed silently" gotchas, but the argparse one bites at the resolved-vs-raw layering boundary, not the falsy-value one.
+
+## Headless matplotlib default for CLI scripts
+
+CLI / CI / web sessions need matplotlib headless. `plt.show()` blocks indefinitely without a display server, masquerading as a hung process — the script appears to print metrics then "stops" forever. Fix at the entry point: default `show_plot=False`, expose `--show-plot` to opt back in. Charts still write to disk via `savefig` — only the GUI window is gated.
+
+```python
+parser.add_argument("--show-plot", action="store_true",
+    help="Open chart interactively. Default off so process exits in CI/web.")
+```
+
+`MPLBACKEND=Agg` (env var) is the alternative when the script can't be changed — Agg backend turns `plt.show()` into a no-op. Either path; the flag is more discoverable than the env var in long-lived projects.
 
 ## Cross-Refs
 

--- a/claude/learnings/refactoring-patterns.md
+++ b/claude/learnings/refactoring-patterns.md
@@ -1,5 +1,5 @@
 Methodology for safe, incremental refactoring: survey-first approach, commit granularity, phased execution, PR splitting, and content-loss audits.
-- **Keywords:** refactoring, survey, grep, commit granularity, factory vs hooks, React Context, PR splitting, risk profile, phased refactoring, test layering, content-loss audit, bulk rename, parallel batch, vendor integration, domain wiring, prudential gate, mechanical gate, Docker smoke test, runtime import check, CMD path change, ModuleNotFoundError, sub-functions, engine, DSL, rule chain, combinator, named branch, abstraction tax
+- **Keywords:** refactoring, survey, grep, commit granularity, factory vs hooks, React Context, PR splitting, risk profile, phased refactoring, test layering, content-loss audit, bulk rename, bulk line deletion, config-dict script, parallel batch, vendor integration, domain wiring, prudential gate, mechanical gate, Docker smoke test, runtime import check, CMD path change, ModuleNotFoundError, sub-functions, engine, DSL, rule chain, combinator, named branch, abstraction tax
 - **Related:** ~/.claude/learnings/code-quality-instincts.md, ~/.claude/learnings/process-conventions.md, ~/.claude/learnings/testing-patterns.md
 
 ---
@@ -207,6 +207,33 @@ Introduce the flag as part of the first PR that touches the affected call site �
 Issue bodies state ACs but rarely state the *boundary* — what's deferred to the next PR vs done now. The linked design or implementation plan gives the phase context that prevents scope creep. Without it, ACs like "all calls route through the adapter" sound total when the plan actually splits them across this PR (libs surface), the next PR (internal factories), and a third (test-mocking migration).
 
 Order: issue body for ACs → linked plan for phase boundaries → code for current state → only then estimate scope.
+
+## Targeted bulk line-deletion via Python config-dict script
+
+When a sweep needs to delete N hand-picked lines across M files (e.g., stripping restatement docstrings flagged by manual review), a small Python script with `{path: [line_numbers]}` config beats N `Edit` calls or fragile sed regex:
+
+```python
+STRIP = {
+    "tests/foo.py": [22, 45, 67, ...],   # line numbers from manual triage
+    "tests/bar.py": [12, 88, ...],
+}
+
+def process(path, line_nums):
+    lines = open(path).readlines()
+    drop = set(n - 1 for n in line_nums)
+    drop |= {n + 1 for n in drop if n + 1 < len(lines) and lines[n + 1].strip() == ""}
+    open(path, "w").writelines(ln for i, ln in enumerate(lines) if i not in drop)
+```
+
+**Why this beats alternatives:**
+- The dict IS the audit trail — operator can read the rubric and the script in one glance.
+- One pass per file vs. N `Edit` calls; no per-file Read-before-Edit cycle.
+- Reversible: adjust the dict and re-run on a fresh checkout.
+- Auto-strips the trailing blank line so class-with-just-methods doesn't end up with a stray gap.
+
+**When sed is wrong here:** regex over `class … docstring … blank … def … docstring` is fragile to indent and accidentally catches helper docstrings you wanted to keep. Use sed for regex bulk rewrites (see `~/.claude/learnings/bash-patterns.md` → "Bulk Path Rewriting with sed Files"); use this script for hand-curated line lists where the classification lived in the operator's head.
+
+**Workflow:** read each file once → classify line-by-line into the strip set → run script → run tests + lint. The judgment lives in the dict; the script is just executor.
 
 ## Tuple → dataclass mock migration: replace_all per unique value
 

--- a/claude/learnings/review-conventions.md
+++ b/claude/learnings/review-conventions.md
@@ -89,6 +89,17 @@ Identifying an issue ("this looks off") and suggesting a fix ("change it to X") 
 - **Think independently about what would make the content better.** Even within a correctly-applied rule, the default remedy may be wrong. "Renumber sequentially" flattens a deliberate grouping; "restructure as sub-items" preserves the author's intent. Lead with the suggestion that improves the content, not the one the rule defaults to.
 - **When uncertain, identify without prescribing.** "This `3a` numbering looks odd — is the intent to group these as variants of the same gotcha, or are they independent items?" surfaces the issue without committing to a fix direction.
 
+### Inline review comment shape: recommendation-first
+
+The diff anchor IS the problem statement — don't restate what the diff shows.
+
+- **Lead with the recommendation.** Drop the diff-restatement preamble.
+- **One fix > tradeoff tree.** Pick one and say so; alternatives can come up in the reply if the addresser pushes back. Listing options with cost annotations turns the comment into a planning artifact.
+- **Sparse cross-refs.** Cite a learning only when the citation isn't self-evident from the recommendation. `Per X → "Y"` adds zero value when the comment already explains Y.
+- **Code earns its lines.** A 3-line working fix beats a paragraph explaining the fix.
+
+Target 1-2 paragraphs per inline. If a comment exceeds that, ask whether each paragraph adds new content or echoes the anchor.
+
 ### Prioritize findings by impact, not discovery order
 
 When a review produces more findings than the author can reasonably act on, rank by:

--- a/claude/learnings/terraform-patterns.md
+++ b/claude/learnings/terraform-patterns.md
@@ -1,5 +1,5 @@
 Terraform / OpenTofu patterns and IaC review gotchas.
-- **Keywords:** terraform, opentofu, tf, iac, hcl, var, data-source, lifecycle, templatefile, secrets
+- **Keywords:** terraform, opentofu, tf, iac, hcl, var, data-source, lifecycle, templatefile, secrets, prevent_destroy, ephemeral env, dev sandbox, agent-driven IaC, AWS account boundary, multi-account, organizations sub-account
 - **Related:** none
 
 ## Fallback-Source Pattern: Always Gate `data` with `count`
@@ -71,6 +71,20 @@ aws ec2 describe-addresses --filters Name=tag:Environment,Values=dev \
 ```
 
 Defense in depth: `AWS_PROFILE` guard + `Environment=<env>` tag filter are independent failure domains. One gate failing doesn't expose prod resources.
+
+## Agent-Driven IaC: Account Boundary > IAM Scope
+
+When an environment exists for AI agents to iterate on infra (apply, destroy, re-apply without operator-in-the-loop), the boundary between agent-touchable and untouchable resources should be **AWS account, not IAM policy**.
+
+| Mechanism | Failure mode |
+|---|---|
+| Read-only IAM on the agent's role | Agent observes but cannot iterate end-to-end — defeats the purpose of having a sandbox. |
+| Scoped-write IAM (`Allow` on `dev/*`, `Deny` on `prod/*`) | Policy correctness is the only thing keeping prod safe. One misauthored `Condition` exposes prod. |
+| Separate AWS account; agent has credentials only for the dev account | Mathematical isolation. Prod credentials physically aren't in the agent's scope; no policy bug crosses the boundary. |
+
+The account-boundary model also unblocks dev as a real integration test bed — agent can apply the same modules prod uses, observe alarms, validate teardown — instead of a shadow environment with read-only fidelity.
+
+Operator setup is one-time: AWS Organizations sub-account, bootstrap an IAM user with `AdministratorAccess` *inside* the dev account (the account boundary is the safety wall, so permissive IAM inside it doesn't expand blast radius), add a named profile to `~/.aws/credentials`. Optionally enforce `Environment=<env>` via Organizations tag policy as defense-in-depth for tag-filtered destroy sweeps. State backend can be the same S3 bucket as prod with a different `key` prefix; bucket-level IAM keeps the dev role from writing under `prod/*`.
 
 ## Terraform PR Verification Ladder
 

--- a/claude/learnings/testing/testing-patterns.md
+++ b/claude/learnings/testing/testing-patterns.md
@@ -1,6 +1,6 @@
 Testing recipes for Vitest/React Testing Library, Next.js route handlers, cross-implementation fixtures, Python test isolation, and mock design.
 - **Keywords:** Vitest, React Testing Library, renderHook, vi.mock, vi.hoisted, jsdom, localStorage, pytest, pytest.raises, module-level singleton, import side effects, UTC, datetime, cross-implementation fixtures, mock coupling, test helpers, mockClear, mockReset, mockResolvedValue, beforeEach, afterEach, call history, cross-test leakage
-- **Related:** ~/.claude/learnings/frontend/nextjs.md, ~/.claude/learnings/playwright-patterns.md, ~/.claude/learnings/code-quality-instincts.md, ~/.claude/learnings/frontend/react-frontend-gotchas.md
+- **Related:** ~/.claude/learnings/frontend/nextjs.md, ~/.claude/learnings/testing/playwright-patterns.md, ~/.claude/learnings/code-quality-instincts.md, ~/.claude/learnings/frontend/react-frontend-gotchas.md
 
 ---
 

--- a/claude/skill-references/INDEX.md
+++ b/claude/skill-references/INDEX.md
@@ -1,0 +1,83 @@
+# Skill References — Quick Index
+
+Helpers, templates, and reference docs under `~/.claude/skill-references/`. **Check this first before writing non-trivial Bash** (loops, `gh -q '<format>'` quoted formats, multi-step pipes) — there's likely a helper that runs allowlist-free via `Bash(bash ~/.claude/skill-references/**)`.
+
+## Three Shapes
+
+| Shape | Path glob | Invoke |
+|-------|-----------|--------|
+| Executable wrapper | `*.sh` (top-level, **not** ending in `-template.sh`) | `bash <path> <args>` |
+| Template | `*-template.sh` (top-level) | Consumed by `fill-template.sh`, not run directly |
+| Platform command stub | `{github,gitlab}/commands/*.sh` | 1–3 lines with `<N>`, `{owner}/{repo}` placeholders. Inlined into `claude -p` prompts via `fill-template.sh`. Don't `bash` them — read the file, run the underlying CLI directly. |
+
+## Executable Wrappers
+
+| Helper | Usage | What it does |
+|--------|-------|--------------|
+| `director-bootstrap.sh` | `bash <path> <timestamp>` | Scaffold director session dir (`session.json`, `decisions.md`). Errors if exists. |
+| `init-sweep-pr-dir.sh` | `bash <path> <run_dir> <pr_numbers...>` | Scaffold PR sweep run dir (`pr-<N>/` + `sweep-pr-preflight.md`). |
+| `fill-template.sh` | `bash <path> <template> <data-dir> > out` | Substitute `{KEY}` / `{{KEY}}` / `{@file}` / `{{#KEY}}...{{/KEY}}` from `<data-dir>/metadata.json`. Pure string subst, no AI. |
+| `sweep-prs-generate-runner.sh` | `bash <path> <RUN_DIR>` | Generate per-PR `prompt.txt` + `let-it-rip.sh` for review/address. Reads `<RUN_DIR>/metadata.json`. |
+| `work-items-generate-runner.sh` | `bash <path> <RUN_DIR>` | Same for `sweep:work-items` (issue dirs + worktree setup). |
+| `sweep-status-summary.sh` | `bash <path> <RUN_DIR> [--logs N\|--retro]` | Per-item status+state table. `--logs N` tails each `output.log` (storm-diagnosis path). `--retro` also dumps `results.md` + `learnings.md`. |
+| `sweep-status.sh` | `bash <path> <run-dir>` | Older variant — pr-only, no log tailing. Prefer `sweep-status-summary.sh`. |
+| `sweep-results.sh` | `bash <path> <run-dir>` | Dump `results.md` + `learnings.md` per item. Subset of `--retro`. |
+| `audit-permissions.sh` | `bash <path> <run-dir>` | Scan `raw.jsonl` for permission denials, suggest patterns to add to `settings.json`. |
+| `permission-analyzer.sh` | `bash <path>` (env: `SESSIONS_LIMIT`, `MIN_COUNT`) | Rank read-only Bash/MCP candidates for allowlist promotion across recent transcripts. |
+| `gh-issues-fetch-state.sh` | `bash <path> <N> [<N> ...]` | Fetch state + updatedAt + latest-comment metadata for GH issues. JSON output, `===issue-<N>===` separators. |
+| `stream-monitor.sh` | (piped) `... \| claude -p ... \| stream-monitor.sh <PR_DIR> \| tee raw.jsonl` | Pass-through filter; writes `live.md` events as side effect. Used by runners, rarely by hand. |
+
+## Templates
+
+| Template | Filled by | Output |
+|----------|-----------|--------|
+| `parallel-claude-runner-template.sh` | `sweep-prs-generate-runner.sh` | `<RUN_DIR>/let-it-rip.sh` for review/address |
+| `work-items-runner-template.sh` | `work-items-generate-runner.sh` | `<RUN_DIR>/let-it-rip.sh` for work-items |
+| `vp-agent-template.sh` | (run directly) `bash <path> [TASK] [RUN_DIR_BASE]` | Multi-tier VP→Director→Worker launcher (research/exploration, not sweep) |
+
+## Platform Command Stubs by Purpose
+
+`{github,gitlab}/commands/*.sh` — ~35 stubs each, GitHub/GitLab parity except where noted. They're command-text templates.
+
+| Category | Stubs |
+|----------|-------|
+| PR fetch | `fetch-pr-watermark`, `fetch-pr-base-branch`, `fetch-pr-branches`, `consolidated-fetch`, `check-pr-mergeable` |
+| PR list | `list-open-prs`, `list-prs-by-branch`, `list-prs-by-issue-ref` |
+| Review fetch | `fetch-review-comments`, `fetch-review-commits`, `fetch-review-details`, `fetch-review-diff`, `fetch-review-files`, `batch-fetch-reviews`, `check-existing-review`, `count-total-reviews`, `find-approved-reviewers` |
+| Review post | `create-review`, `post-code-review`, `post-review-comments`, `update-review` |
+| Inline comments | `fetch-inline-comments`, `fetch-recent-inline-comments`, `fetch-latest-inline-comment-id`, `reply-to-inline-comment` |
+| Top-level comments | `post-top-level-comment`, `post-issue-comment`, `react-to-comment` |
+| Activity / checkout | `fetch-activity-signals`, `checkout-review` |
+| Issue ops | `fetch-issue`, `fetch-issue-comments`, `fetch-issue-with-comments`, `check-issue-state`, `list-open-issues`, `link-sub-issue` (gh-only), `unlink-sub-issue` (gh-only), `create-milestone` (gh-only) |
+| Platform check | `verify-platform-access` |
+
+When no executable wrapper covers your need, fall back to plain CLI under the platform's allowlist (`Bash(gh *)`, `Bash(glab *)`) and parse JSON via separate `jq` — not inline `gh -q '<format>'` (quoted format strings prompt for permission).
+
+## Reference Docs (.md)
+
+Read by skills via `@`/Skill tool, not invoked directly. Listed here so cross-refs from learnings/playbooks resolve at a glance.
+
+| File | Domain |
+|------|--------|
+| `director-playbook.md` | Director orchestration (eager-loaded by /director Phase 1) |
+| `director-decision-matrix.md` | Escalation tiers, routine vs judgment (eager-loaded by /director) |
+| `sweep-scaffold.md` | Shared scaffold for sweep:*-prs / sweep:work-items |
+| `sweep-pr-preflight.md` | Copied into PR sweep run dirs |
+| `sweep-agent-preflight.md` | Copied into work-items run dirs |
+| `artifact-contract.md` | Manifest schema + run-dir structure for director-managed skills |
+| `agent-prompting.md` | Patterns for writing `claude -p` prompts |
+| `subagent-patterns.md` | Subagent orchestration recipes |
+| `decision-matrix.md` | Generic decision matrix (non-director) |
+| `code-quality-checklist.md` | Code review checklist |
+| `corpus-cross-reference.md` | Cross-ref helpers for learning corpus |
+| `exploration-report-shape.md` | Output shape for `/explore-repo` |
+| `persona-auto-detect.md` | Persona matching heuristics |
+| `platform-detection.md` | GitHub vs GitLab detection |
+| `request-interaction-base.md` | Base for `git:*` request skills |
+| `review-comment-classification.md` | Reviewer comment classification (drives reactions) |
+
+## Cross-Refs
+
+- `~/.claude/learnings/claude-code/sweep-sessions.md` → "Template Scripts Fail `bash -n` Validation" — full executable-vs-stub distinction.
+- `~/.claude/learnings/claude-code/multi-agent/director/observability.md` → "Use `sweep-status-summary.sh`" — three-mode flag table.
+- `~/.claude/learnings/claude-code/multi-agent/director/failure-modes.md` → "Compound-Mode Storm" + "30-Second Exit Diagnosis" — when to reach for `--logs N`.

--- a/claude/skill-references/INDEX.md
+++ b/claude/skill-references/INDEX.md
@@ -26,6 +26,7 @@ Helpers, templates, and reference docs under `~/.claude/skill-references/`. **Ch
 | `permission-analyzer.sh` | `bash <path>` (env: `SESSIONS_LIMIT`, `MIN_COUNT`) | Rank read-only Bash/MCP candidates for allowlist promotion across recent transcripts. |
 | `gh-issues-fetch-state.sh` | `bash <path> <N> [<N> ...]` | Fetch state + updatedAt + latest-comment metadata for GH issues. JSON output, `===issue-<N>===` separators. |
 | `stream-monitor.sh` | (piped) `... \| claude -p ... \| stream-monitor.sh <PR_DIR> \| tee raw.jsonl` | Pass-through filter; writes `live.md` events as side effect. Used by runners, rarely by hand. |
+| `vp-agent-template.sh` | `bash <path> [TASK] [RUN_DIR_BASE]` | Multi-tier VP→Director→Worker launcher (research/exploration, not sweep). Note: `-template` suffix is a misnomer — this is a direct-run launcher, not a `fill-template.sh` input. |
 
 ## Templates
 
@@ -33,7 +34,6 @@ Helpers, templates, and reference docs under `~/.claude/skill-references/`. **Ch
 |----------|-----------|--------|
 | `parallel-claude-runner-template.sh` | `sweep-prs-generate-runner.sh` | `<RUN_DIR>/let-it-rip.sh` for review/address |
 | `work-items-runner-template.sh` | `work-items-generate-runner.sh` | `<RUN_DIR>/let-it-rip.sh` for work-items |
-| `vp-agent-template.sh` | (run directly) `bash <path> [TASK] [RUN_DIR_BASE]` | Multi-tier VP→Director→Worker launcher (research/exploration, not sweep) |
 
 ## Platform Command Stubs by Purpose
 

--- a/claude/skill-references/director-playbook.md
+++ b/claude/skill-references/director-playbook.md
@@ -68,16 +68,22 @@ The monitor appends typed events to `live.md` as a side effect. Reference docs l
 
 ### Director Intervention
 
-The runner handles inactivity detection and single-retry recovery automatically. The director only intervenes after the runner exhausts retries and escalates via `state.md`. Read `live.md` only when investigating an escalation — never as a primary monitoring channel.
+The runner handles inactivity detection and single-retry recovery automatically. The director only intervenes after the runner exhausts retries and escalates via `state.md`. Read logs only when investigating an escalation — never as a primary monitoring channel.
+
+**Log inspection — always via the allowlisted helper:**
+```
+bash ~/.claude/skill-references/sweep-status-summary.sh <RUN_DIR> --logs N
+```
+Tails each item's `output.log` (stream-json: tool calls, errors, `rate_limit_event`, `is_error`). Do NOT `tail`/`cat` `live.md` or `output.log` directly — those aren't allowlisted and prompt the operator. Need turn text or full event history? See `failure-modes.md` for the `raw.jsonl` deep-inspection path.
 
 | Detection (from state.md) | Action |
 |---------------------------|--------|
-| `state: errored` + `escalation: needs-director` | Read `live.md` tail, investigate root cause, write directive for next launch |
+| `state: errored` + `escalation: needs-director` | `sweep-status-summary.sh --logs 30` for that run, investigate root cause, write directive for next launch |
 | `state: rate-limited` | Check `.rate-limited` sentinel, advise operator on retry timing |
 | `escalation: permission_denial` | Fix permission in settings, write directive |
 | `escalation: repeated_errors` | Investigate root cause, write directive or escalate |
 
-**Failure-mode shortcut:** if `state: completed` but `live.md` shows `is_error: true` + `context_used_tokens: 0` + short duration on multiple sessions same cycle, that's the **rate-limit storm** — fresh-timestamp restart, not in-place retry. See `failure-modes.md`.
+**Failure-mode shortcut:** if `state: completed` but `output.log` (via `sweep-status-summary.sh --logs N`) shows `"is_error":true` + `context_used_tokens: 0` + short duration on multiple sessions same cycle, that's the **rate-limit storm** — fresh-timestamp restart, not in-place retry. See `failure-modes.md`.
 
 ## Monitoring Table Format
 


### PR DESCRIPTION
## Summary

Multi-area refresh: new `skill-references/INDEX.md` (allowlisted Bash helper catalog), Bash-quoting + path-resolution guidance in root CLAUDE.md files, four git skill command refinements, a broad learnings batch, and a tables-first refactor of the explore-repo skill outputs. Split into themed commits for individual review.

## Key changes

| # | SHA | Theme |
|---|-----|-------|
| 1 | `cf6bb2b` | Persona reference path fixes across 8 `set-persona/*.md` files |
| 2 | `956fbfe` | New `skill-references/INDEX.md` (wrappers / templates / platform-command stubs); `CLAUDE.md` gains Read/Edit path-string-keying note; `claude/CLAUDE.md` routes complex Bash to the INDEX; minor `director-playbook` touch-up |
| 3 | `276fe80` | Git skill refinements: `address-request-edge-cases`, `prune-merged/SKILL`, `team-review-request/{persona-routing, re-review-mode}` |
| 4 | `a7465eb` | Learnings batch: 25 refreshed + 2 new (`docker-image-patterns`, `financial/tradestation-api`) — bash/cicd/claude-authoring/director cluster/quality/platform-tools/sweep-sessions/web-sync/code-quality/docker-compose/financial/git/process/python/refactoring/review/terraform/testing |
| 5 | `dcb18fa` | `explore-repo` skill: tables-first / diagrams-first refactor of the 7 domain outputs (`structure`, `api-surface`, `data-model`, `integrations`, `processing-flows`, `config-and-ops`, `testing`) plus `SYSTEM_OVERVIEW.md` and `inconsistencies.md`; explicit FORMAT rules in `agent-prompts.md`; section intros capped at 3 sentences |
| 6 | `85111d7` | Learnings batch: `git commit -F - <<'EOF'` heredoc; section-descriptor / preview / section-headings-as-API skill design notes; when-to-fold-an-agent-into-a-persona; `git branch -f` for non-current branch rewind |
| 7 | `7c18209` | New personas: `python-engineer` (language-only base lens) and `python-quant-dev` (composes via `## Extends:`) |
| 8 | `f0cb32c` | Learnings batch: single-resource 200+error envelope; sub-`CLAUDE.md` plain-path lazy index (not `@`); verify-before-adding to default-iterated registries |
| 9 | `07be237` | `explore-repo` skill: detect unreachable stale-commit via `git rev-parse` and fall back to full rescan |
| 10 | `2e680b8` | Learnings batch (git-patterns): untracked-file stash conflicts via `stash@{0}^3`; misleading `git apply --3way --check` output; atomic commit split via temp-revert; preemptive `(#NNN)` subject verification |

## Screenshots

N/A

## Test plan

- [x] Working tree clean after split commits; each commit scope-clean (verified via `git diff --cached --stat` per stage)
- [x] `main` rewound to `origin/main` — `cf6bb2b` lives on this branch only
- [ ] Spot-check INDEX.md helper paths resolve (manual on first reuse)
- [ ] Spot-check explore-repo output against the new format on next scan

## Checklist

- [x] No sensitive data (markdown content only)
- [x] Conventional-commit prefixes per repo convention
- [ ] Squash before merge if single-commit shape is preferred (10 commits left intentionally for per-theme review)

---
Generated with [Claude Code](https://claude.ai/code)
